### PR TITLE
Replace mail branding editor with CodeMirror

### DIFF
--- a/app/admin/mail-branding/page.tsx
+++ b/app/admin/mail-branding/page.tsx
@@ -61,7 +61,7 @@ type MailBrandingFormState = {
   colors: MailBrandingColors;
 };
 
-const MOBILE_PREVIEW_WIDTH = 480;
+const MOBILE_PREVIEW_WIDTH = 580;
 const PREVIEW_FRAME_OUTER_WIDTH = MOBILE_PREVIEW_WIDTH + 48;
 const PREVIEW_CARD_MAX_WIDTH = PREVIEW_FRAME_OUTER_WIDTH + 32;
 

--- a/app/admin/mail-branding/page.tsx
+++ b/app/admin/mail-branding/page.tsx
@@ -3,8 +3,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useId } from "react";
 import type { ChangeEvent, FormEvent } from "react";
 import type { TwigModule, TwigTemplate } from "twig";
-import Editor from "@monaco-editor/react";
-import type * as MonacoEditorType from "monaco-editor";
+import CodeMirror from "@uiw/react-codemirror";
+import "@uiw/react-codemirror/dist/codemirror.css";
+import { html } from "@codemirror/lang-html";
+import { tagMatching, bracketMatching } from "@codemirror/language";
+import { oneDark } from "@codemirror/theme-one-dark";
+import { EditorView } from "@codemirror/view";
 import { Code2, FunctionSquare, Loader2, Plus, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -24,8 +28,6 @@ import type {
   MailTemplateUpdatePayload,
   MailTemplateSummary,
 } from "@/types/mail";
-
-type Monaco = typeof import("monaco-editor");
 
 interface StatusMessage {
   type: "success" | "error";
@@ -1307,9 +1309,7 @@ const MailBrandingPage = () => {
   const templateEditorLabelId = useId();
   const templateVariableSelectId = useId();
   const templateFunctionSelectId = useId();
-  const monacoEditorRef = useRef<MonacoEditorType.editor.IStandaloneCodeEditor | null>(null);
-  const monacoInstanceRef = useRef<Monaco | null>(null);
-  const monacoConfiguredRef = useRef(false);
+  const editorViewRef = useRef<EditorView | null>(null);
   const templateContentRef = useRef(templateContent);
   const [isClient, setIsClient] = useState(false);
 
@@ -1429,265 +1429,22 @@ const MailBrandingPage = () => {
     setIsClient(true);
   }, []);
 
-  const configureMonaco = useCallback(
-    (monaco: Monaco) => {
-      if (!monaco) {
-        return;
-      }
-
-      if (!monacoConfiguredRef.current) {
-        const registeredLanguages = monaco.languages.getLanguages();
-        const hasTwig = registeredLanguages.some((language) => language.id === "twig");
-
-        if (!hasTwig) {
-          const twigKeywords = [
-            "apply",
-            "autoescape",
-            "block",
-            "do",
-            "embed",
-            "extends",
-            "filter",
-            "flush",
-            "for",
-            "if",
-            "import",
-            "include",
-            "macro",
-            "sandbox",
-            "set",
-            "spaceless",
-            "trans",
-            "use",
-            "with",
-            "only",
-            "elseif",
-            "else",
-            "endapply",
-            "endautoescape",
-            "endblock",
-            "endembed",
-            "endfilter",
-            "endfor",
-            "endif",
-            "endmacro",
-            "endsandbox",
-            "endset",
-            "endspaceless",
-            "endtrans",
-            "endwith",
-            "in",
-            "is",
-            "not",
-            "and",
-            "or",
-          ];
-
-          monaco.languages.register({ id: "twig" });
-          monaco.languages.setLanguageConfiguration("twig", {
-            comments: {
-              blockComment: ["{#", "#}"],
-            },
-            brackets: [
-              ["{%", "%}"],
-              ["{{", "}}"],
-              ["{#", "#}"],
-              ["<", ">"],
-              ["(", ")"],
-              ["[", "]"],
-              ["{", "}"],
-            ],
-            autoClosingPairs: [
-              { open: "{%", close: "%}" },
-              { open: "{{", close: "}}" },
-              { open: "{#", close: "#}", notIn: ["string"] },
-              { open: "'", close: "'", notIn: ["string"] },
-              { open: '"', close: '"', notIn: ["string"] },
-              { open: "(", close: ")" },
-              { open: "[", close: "]" },
-              { open: "{", close: "}" },
-              { open: "<", close: ">" },
-            ],
-            surroundingPairs: [
-              { open: "'", close: "'" },
-              { open: '"', close: '"' },
-              { open: "(", close: ")" },
-              { open: "[", close: "]" },
-              { open: "{", close: "}" },
-              { open: "<", close: ">" },
-            ],
-            folding: {
-              markers: {
-                start: new RegExp("^\\s*\\{%[-\\s]*(?:if|for|block|embed|filter|macro|apply|trans|spaceless)\\b"),
-                end: new RegExp("^\\s*\\{%[-\\s]*end(?:if|for|block|embed|filter|macro|apply|trans|spaceless)\\b"),
-              },
-            },
-          });
-
-          monaco.languages.setMonarchTokensProvider("twig", {
-            defaultToken: "",
-            tokenPostfix: "",
-            ignoreCase: true,
-            keywords: twigKeywords,
-            tokenizer: {
-              root: [
-                [/{#/, { token: "comment.twig", next: "@commentBlock" }],
-                [/{%/, { token: "keyword.twig", next: "@tagState" }],
-                [/{{/, { token: "variable.twig", next: "@outputState" }],
-                [/<!DOCTYPE/, "metatag.html", "@doctypeState"],
-                [/<!--/, "comment.html", "@htmlComment"],
-                [/<\/?[\w:-]+/, { token: "tag.html", next: "@tag" }],
-                [/[^<{]+/, "text"],
-              ],
-              commentBlock: [
-                [/[^#]+/, "comment.twig"],
-                [/#}/, { token: "comment.twig", next: "@pop" }],
-                [/#/, "comment.twig"],
-              ],
-              tag: [
-                [/\s+/, ""],
-                [/([\w:-]+)(?=\s*=)/, "attribute.name.html"],
-                [/([\w:-]+)/, "attribute.name.html"],
-                [/\s*=\s*/, "delimiter.html", "@attributeValue"],
-                [/(\/?>)/, { token: "delimiter.html", next: "@pop" }],
-              ],
-              attributeValue: [
-                [/"[^"]*"/, "attribute.value.html", "@pop"],
-                [/'[^']*'/, "attribute.value.html", "@pop"],
-                [/[^\s>]+/, "attribute.value.html", "@pop"],
-              ],
-              htmlComment: [
-                [/[^-]+/, "comment.html"],
-                [/-->/, { token: "comment.html", next: "@pop" }],
-                [/[-]/, "comment.html"],
-              ],
-              doctypeState: [
-                [/[^>]+/, "metatag.html"],
-                [/>/, { token: "metatag.html", next: "@pop" }],
-              ],
-              tagState: [
-                [/\s+/, ""],
-                [/%}/, { token: "keyword.twig", next: "@pop" }],
-                [/\|/, "operator.twig"],
-                [/[@$]?[\w:]+/, {
-                  cases: {
-                    "@keywords": "keyword.twig",
-                    "@default": "identifier.twig",
-                  },
-                }],
-                [/\b(?:true|false|null|empty)\b/, "constant.language.twig"],
-                [/\d+(?:\.\d+)?/, "number"],
-                [/'[^']*'/, "string"],
-                [/"[^"]*"/, "string"],
-                [/[:,.]/, "delimiter"],
-                [/[[\]{}()]/, "delimiter"],
-                [/[+\-*/%<>!=&|~]/, "operator.twig"],
-              ],
-              outputState: [
-                [/\s+/, ""],
-                [/}}/, { token: "variable.twig", next: "@pop" }],
-                [/\|/, "operator.twig"],
-                [/[@$]?[\w:]+/, {
-                  cases: {
-                    "@keywords": "keyword.twig",
-                    "@default": "identifier.twig",
-                  },
-                }],
-                [/\b(?:true|false|null|empty)\b/, "constant.language.twig"],
-                [/\d+(?:\.\d+)?/, "number"],
-                [/'[^']*'/, "string"],
-                [/"[^"]*"/, "string"],
-                [/[:,.]/, "delimiter"],
-                [/[[\]{}()]/, "delimiter"],
-                [/[+\-*/%<>!=&|~]/, "operator.twig"],
-              ],
-            },
-          });
-        }
-
-        monaco.editor.defineTheme("mail-branding", {
-          base: "vs",
-          inherit: true,
-          rules: [
-            { token: "comment.twig", foreground: "94A3B8", fontStyle: "italic" },
-            { token: "comment.html", foreground: "94A3B8", fontStyle: "italic" },
-            { token: "keyword.twig", foreground: "2563EB", fontStyle: "bold" },
-            { token: "variable.twig", foreground: "9333EA", fontStyle: "bold" },
-            { token: "identifier.twig", foreground: "1A3661" },
-            { token: "constant.language.twig", foreground: "0F766E", fontStyle: "bold" },
-            { token: "operator.twig", foreground: "DC2626" },
-            { token: "number", foreground: "B45309" },
-            { token: "string", foreground: "047857" },
-            { token: "tag.html", foreground: "1D4ED8", fontStyle: "bold" },
-            { token: "attribute.name.html", foreground: "2563EB" },
-            { token: "attribute.value.html", foreground: "047857" },
-            { token: "metatag.html", foreground: "475569" },
-            { token: "delimiter.html", foreground: "64748B" },
-          ],
-          colors: {
-            "editor.background": "#ffffff",
-            "editor.foreground": "#1f2937",
-            "editorLineNumber.foreground": "#9ca3af",
-            "editorLineNumber.activeForeground": "#2563eb",
-            "editor.selectionBackground": "#dbeafe",
-            "editor.selectionHighlightBackground": "#bfdbfe80",
-            "editorCursor.foreground": "#1a3661",
-            "editor.lineHighlightBackground": "#f8fafc",
-            "editorGutter.background": "#ffffff",
-            "editorIndentGuide.background": "#e2e8f0",
-            "editorIndentGuide.activeBackground": "#cbd5f5",
-            "scrollbarSlider.background": "#e5e7eb",
-            "scrollbarSlider.hoverBackground": "#d1d5db",
-            "scrollbarSlider.activeBackground": "#9ca3af",
-          },
-        });
-
-        monacoConfiguredRef.current = true;
-      }
-    },
-    [],
-  );
-
-  const handleEditorWillMount = useCallback(
-    (monaco: Monaco) => {
-      configureMonaco(monaco);
-      monacoInstanceRef.current = monaco;
-    },
-    [configureMonaco],
-  );
-
-  const handleEditorDidMount = useCallback(
-    (editor: MonacoEditorType.editor.IStandaloneCodeEditor, monaco: Monaco) => {
-      monacoInstanceRef.current = monaco;
-      configureMonaco(monaco);
-      monaco.editor.setTheme("mail-branding");
-      monacoEditorRef.current = editor;
-      const model = editor.getModel();
-      if (model) {
-        model.updateOptions({ tabSize: 2, insertSpaces: true });
-      }
-      templateContentRef.current = editor.getValue();
-    },
-    [configureMonaco],
-  );
-
   const handleEditorChange = useCallback(
-    (value?: string) => {
-      const nextValue = value ?? "";
+    (nextValue: string) => {
       templateContentRef.current = nextValue;
       setTemplateContent((prev) => (prev === nextValue ? prev : nextValue));
     },
-    [],
+    [setTemplateContent],
   );
+
+  const handleEditorCreate = useCallback((view: EditorView) => {
+    editorViewRef.current = view;
+    templateContentRef.current = view.state.doc.toString();
+  }, []);
 
   useEffect(
     () => () => {
-      const editor = monacoEditorRef.current;
-      if (editor) {
-        editor.dispose();
-        monacoEditorRef.current = null;
-      }
-      monacoInstanceRef.current = null;
+      editorViewRef.current = null;
     },
     [],
   );
@@ -2115,64 +1872,36 @@ const MailBrandingPage = () => {
         options?.placeholder && options.placeholder.length > 0
           ? options.placeholder
           : undefined;
-      const editor = monacoEditorRef.current;
-      const monaco = monacoInstanceRef.current;
+      if (!isEditorEditable) {
+        return;
+      }
+      const view = editorViewRef.current;
 
-      if (editor && monaco) {
-        const model = editor.getModel();
-        if (model) {
-          const currentSelection = editor.getSelection();
-          const endPosition = model.getPositionAt(model.getValueLength());
-          const effectiveSelection =
-            currentSelection ??
-            new monaco.Selection(
-              endPosition.lineNumber,
-              endPosition.column,
-              endPosition.lineNumber,
-              endPosition.column,
-            );
+      if (view) {
+        const mainSelection = view.state.selection.main;
+        const docLength = view.state.doc.length;
+        const hasFocus = view.hasFocus();
+        const from = hasFocus ? mainSelection.from : docLength;
+        const to = hasFocus ? mainSelection.to : docLength;
+        const placeholderIndex = placeholder ? snippet.indexOf(placeholder) : -1;
+        const anchorOffset =
+          placeholderIndex >= 0 ? from + placeholderIndex : from + snippet.length;
+        const headOffset =
+          placeholderIndex >= 0 && placeholder
+            ? anchorOffset + placeholder.length
+            : anchorOffset;
 
-          const startOffset = model.getOffsetAt(
-            effectiveSelection.getStartPosition(),
-          );
-          const placeholderIndex = placeholder ? snippet.indexOf(placeholder) : -1;
-          const anchorOffset =
-            placeholderIndex >= 0
-              ? startOffset + placeholderIndex
-              : startOffset + snippet.length;
-          const headOffset =
-            placeholderIndex >= 0 && placeholder
-              ? anchorOffset + placeholder.length
-              : anchorOffset;
+        view.dispatch({
+          changes: { from, to, insert: snippet },
+          selection: { anchor: anchorOffset, head: headOffset },
+          scrollIntoView: true,
+        });
 
-          editor.pushUndoStop();
-          editor.executeEdits("mail-branding-snippet", [
-            {
-              range: effectiveSelection,
-              text: snippet,
-              forceMoveMarkers: true,
-            },
-          ]);
-          editor.pushUndoStop();
-
-          const newValue = model.getValue();
-          templateContentRef.current = newValue;
-          setTemplateContent((prev) => (prev === newValue ? prev : newValue));
-
-          const anchorPosition = model.getPositionAt(anchorOffset);
-          const headPosition = model.getPositionAt(headOffset);
-          editor.setSelection(
-            new monaco.Selection(
-              anchorPosition.lineNumber,
-              anchorPosition.column,
-              headPosition.lineNumber,
-              headPosition.column,
-            ),
-          );
-          editor.revealLineInCenter(anchorPosition.lineNumber);
-          editor.focus();
-          return;
-        }
+        const newValue = view.state.doc.toString();
+        templateContentRef.current = newValue;
+        setTemplateContent((prev) => (prev === newValue ? prev : newValue));
+        view.focus();
+        return;
       }
 
       const base = templateContentRef.current ?? "";
@@ -2190,7 +1919,7 @@ const MailBrandingPage = () => {
       setTemplateContent(nextValue);
       setDebouncedContent(nextValue);
     },
-    [setDebouncedContent, setTemplateContent],
+    [isEditorEditable, setDebouncedContent, setTemplateContent],
   );
 
   const handleBrandingSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -2476,48 +2205,33 @@ const MailBrandingPage = () => {
     ? attachmentsList
     : [];
 
-  const editorModelPath = useMemo(() => {
-    if (currentTemplate?.path) {
-      return currentTemplate.path;
-    }
-    if (selectedTemplateKey) {
-      return `${selectedTemplateKey}.twig`;
-    }
-    return "mail-template.twig";
-  }, [currentTemplate, selectedTemplateKey]);
+  const isEditorEditable = Boolean(selectedTemplateKey) && !templateLoading;
 
-  const editorOptions = useMemo<
-    MonacoEditorType.editor.IStandaloneEditorConstructionOptions
-  >(
-    () => ({
-      minimap: { enabled: false },
-      scrollBeyondLastLine: false,
-      fontFamily:
-        "'Fira Code', 'SFMono-Regular', Menlo, Monaco, 'Courier New', monospace",
-      fontSize: 14,
-      lineHeight: 22,
-      wordWrap: "on",
-      wrappingIndent: "same",
-      smoothScrolling: true,
-      automaticLayout: true,
-      renderLineHighlight: "line",
-      lineNumbers: "on",
-      lineNumbersMinChars: 3,
-      glyphMargin: false,
-      contextmenu: true,
-      padding: { top: 16, bottom: 16 },
-      tabSize: 2,
-      insertSpaces: true,
-      quickSuggestions: true,
-      autoClosingBrackets: "languageDefined",
-      autoClosingQuotes: "languageDefined",
-      formatOnPaste: false,
-      formatOnType: false,
-      ariaLabel: "Editor conținut template Twig",
-      readOnly: !selectedTemplateKey || templateLoading,
+  const editorExtensions = useMemo(() => [
+    html({ autoCloseTags: true, matchClosingTags: true }),
+    tagMatching(),
+    bracketMatching(),
+    EditorView.lineWrapping,
+    EditorView.editable.of(isEditorEditable),
+    EditorView.theme({
+      '&': {
+        fontFamily:
+          "'Fira Code', 'SFMono-Regular', Menlo, Monaco, 'Courier New', monospace",
+        fontSize: '14px',
+      },
+      '.cm-scroller': { lineHeight: '1.6' },
+      '.cm-matchingTag': {
+        backgroundColor: 'rgba(56,189,248,.25)',
+        outline: '1px solid rgba(56,189,248,.7)',
+        borderRadius: '2px',
+      },
+      '.cm-nonmatchingTag': {
+        backgroundColor: 'rgba(244,63,94,.2)',
+        outline: '1px solid rgba(244,63,94,.6)',
+      },
     }),
-    [selectedTemplateKey, templateLoading],
-  );
+  ], [isEditorEditable]);
+
 
   const availableVariableMetadata = useMemo(() => {
     const detail = selectedTemplateKey ? templateDetails[selectedTemplateKey] : null;
@@ -3028,35 +2742,38 @@ const MailBrandingPage = () => {
                     </div>
                   )}
                 </div>
-                <div className="mt-4 min-h-[360px]">
-                  {isClient ? (
-                    <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm focus-within:ring-2 focus-within:ring-jade/30 focus-within:ring-offset-2">
-                      <Editor
-                        className="monaco-mail-editor"
-                        value={templateContent}
-                        defaultLanguage="html"
-                        language="html"
-                        theme="mail-branding"
-                        path={editorModelPath}
-                        beforeMount={handleEditorWillMount}
-                        onMount={handleEditorDidMount}
-                        onChange={handleEditorChange}
-                        options={editorOptions}
-                        height="520px"
-                        loading={
-                          <div className="flex min-h-[320px] items-center justify-center text-sm text-gray-500">
-                            Editorul se încarcă...
-                          </div>
-                        }
-                        wrapperProps={{ "aria-labelledby": templateEditorLabelId }}
-                      />
-                    </div>
-                  ) : (
-                    <div className="flex min-h-[360px] items-center justify-center rounded-2xl border border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-sm text-gray-500">
-                      Editorul se încarcă...
-                    </div>
-                  )}
-                </div>
+                  <div className="mt-4 min-h-[360px]">
+                    {isClient ? (
+                      <div className="space-y-3">
+                        <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm focus-within:ring-2 focus-within:ring-jade/30 focus-within:ring-offset-2">
+                          <CodeMirror
+                            value={templateContent}
+                            height="520px"
+                            theme={oneDark}
+                            extensions={editorExtensions}
+                            basicSetup={{
+                              highlightActiveLine: true,
+                              highlightActiveLineGutter: true,
+                              autocompletion: true,
+                              foldGutter: true,
+                            }}
+                            onChange={(value) => handleEditorChange(value)}
+                            onCreateEditor={handleEditorCreate}
+                            aria-labelledby={templateEditorLabelId}
+                            aria-disabled={!isEditorEditable}
+                            className="text-sm"
+                          />
+                        </div>
+                        <p className="text-xs text-gray-500">
+                          Sfaturi: pune cursorul pe numele unui tag (ex: <code>&lt;td&gt;</code>) — perechea se evidențiază automat. Dublu-click pe tag = selectare rapidă.
+                        </p>
+                      </div>
+                    ) : (
+                      <div className="flex min-h-[360px] items-center justify-center rounded-2xl border border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-sm text-gray-500">
+                        Editorul se încarcă...
+                      </div>
+                    )}
+                  </div>
               </div>
 
               <div className="space-y-4 rounded-2xl border border-gray-200 p-4 sm:p-6">

--- a/app/admin/mail-branding/page.tsx
+++ b/app/admin/mail-branding/page.tsx
@@ -6,7 +6,6 @@ import type { TwigModule, TwigTemplate } from "twig";
 import type { SyntaxNode } from "@lezer/common";
 import type { EditorState } from "@codemirror/state";
 import CodeMirror from "@uiw/react-codemirror";
-import "@uiw/react-codemirror/dist/codemirror.css";
 import { html } from "@codemirror/lang-html";
 import { bracketMatching, syntaxTree } from "@codemirror/language";
 import { RangeSetBuilder } from "@codemirror/state";

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -786,8 +786,8 @@ const ReservationPage = () => {
         try {
             const res = await apiClient.createBooking(payload);
             const reservationId =
-                res?.booking_number ||
-                res?.id ||
+                res?.data?.booking_number ||
+                res?.data?.id ||
                 "#" + Math.floor(1000000 + Math.random() * 9000000);
             localStorage.setItem(
                 "reservationData",

--- a/app/globals.css
+++ b/app/globals.css
@@ -72,29 +72,6 @@
     padding-left: 1rem;
 }
 
-.monaco-mail-editor {
-    width: 100%;
-}
-
-.monaco-mail-editor .monaco-editor,
-.monaco-mail-editor .monaco-editor-background,
-.monaco-mail-editor .margin {
-    background-color: transparent !important;
-}
-
-.monaco-mail-editor .monaco-editor .line-numbers {
-    color: rgb(156 163 175 / 1) !important;
-}
-
-.monaco-mail-editor .monaco-editor .view-lines {
-    padding-left: 0.5rem !important;
-    padding-right: 1rem !important;
-}
-
-.monaco-mail-editor .monaco-editor .current-line {
-    background-color: rgba(219, 234, 254, 0.45) !important;
-}
-
 .datetime-field {
     position: relative;
     height: 3rem;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,16 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
-        "@monaco-editor/react": "^4.6.0",
+        "@codemirror/lang-html": "^6.4.10",
+        "@codemirror/language": "^6.11.3",
+        "@codemirror/theme-one-dark": "^6.1.3",
         "@next/bundle-analyzer": "^15.5.2",
+        "@uiw/react-codemirror": "^4.25.2",
         "babel-plugin-react-compiler": "^19.1.0-rc.3",
         "critters": "^0.0.23",
         "eslint-config-next": "^15.5.2",
         "eslint-plugin-react": "^7.37.5",
         "lucide-react": "^0.344.0",
-        "monaco-editor": "^0.52.0",
         "next": "^15.4.6",
         "next-auth": "^4.24.11",
         "next-themes": "^0.3.0",
@@ -138,6 +140,144 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.18.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.7.tgz",
+      "integrity": "sha512-8EzdeIoWPJDsMBwz3zdzwXnUpCzMiCyz5/A3FIPpriaclFCGDkAzK13sMcnsu5rowqiyeQN2Vs2TsOcoDPZirQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.1.tgz",
+      "integrity": "sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.10",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.10.tgz",
+      "integrity": "sha512-h/SceTVsN5r+WE+TVP2g3KDvNoSzbSrtZXCKo4vkKdbfT5t4otuVgngGdFukOO/rwRD2++pCxoh6xD4TEVMkQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.0"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
+      "integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.3.tgz",
+      "integrity": "sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.1.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz",
+      "integrity": "sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
+      "integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
+      "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.38.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.3.tgz",
+      "integrity": "sha512-x2t87+oqwB1mduiQZ6huIghjMt4uZKFEdj66IcXw7+a5iBEvv9lh7EWDRHI7crnD4BMGpnyq/RzmCGbiEZLcvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1356,28 +1496,68 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@monaco-editor/loader": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
-      "integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
+    "node_modules/@lezer/common": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
+      "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.0.tgz",
+      "integrity": "sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw==",
       "license": "MIT",
       "dependencies": {
-        "state-local": "^1.0.6"
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
       }
     },
-    "node_modules/@monaco-editor/react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
-      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+      "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
       "license": "MIT",
       "dependencies": {
-        "@monaco-editor/loader": "^1.5.0"
-      },
-      "peerDependencies": {
-        "monaco-editor": ">= 0.25.0 < 1",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+        "@lezer/common": "^1.0.0"
       }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.10.tgz",
+      "integrity": "sha512-dqpT8nISx/p9Do3AchvYGV3qYc4/rKr3IBZxlHmpIKam56P47RSHkSF5f13Vu9hebS1jM0HmtJIwLbWz1VIY6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
+      "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -2194,6 +2374,59 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@uiw/codemirror-extensions-basic-setup": {
+      "version": "4.25.2",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.2.tgz",
+      "integrity": "sha512-s2fbpdXrSMWEc86moll/d007ZFhu6jzwNu5cWv/2o7egymvLeZO52LWkewgbr+BUCGWGPsoJVWeaejbsb/hLcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": ">=6.0.0",
+        "@codemirror/commands": ">=6.0.0",
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/lint": ">=6.0.0",
+        "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.25.2",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.2.tgz",
+      "integrity": "sha512-XP3R1xyE0CP6Q0iR0xf3ed+cJzJnfmbLelgJR6osVVtMStGGZP3pGQjjwDRYptmjGHfEELUyyBLdY25h0BQg7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.25.2",
+        "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/theme-one-dark": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0",
+        "codemirror": ">=6.0.0",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
@@ -3174,6 +3407,21 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -3235,6 +3483,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/critters": {
       "version": "0.0.23",
@@ -5610,12 +5864,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/monaco-editor": {
-      "version": "0.52.2",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
-      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "license": "MIT"
-    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -6937,12 +7185,6 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "license": "MIT"
     },
-    "node_modules/state-local": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
-      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
-      "license": "MIT"
-    },
     "node_modules/std-env": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
@@ -7192,6 +7434,12 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "license": "MIT"
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
+      "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
       "license": "MIT"
     },
     "node_modules/styled-jsx": {
@@ -7972,6 +8220,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -11,14 +11,16 @@
     "images:webp": "node scripts/convert-images.cjs"
   },
   "dependencies": {
-    "@monaco-editor/react": "^4.6.0",
+    "@codemirror/lang-html": "^6.4.10",
+    "@codemirror/language": "^6.11.3",
+    "@codemirror/theme-one-dark": "^6.1.3",
     "@next/bundle-analyzer": "^15.5.2",
+    "@uiw/react-codemirror": "^4.25.2",
     "babel-plugin-react-compiler": "^19.1.0-rc.3",
     "critters": "^0.0.23",
     "eslint-config-next": "^15.5.2",
     "eslint-plugin-react": "^7.37.5",
     "lucide-react": "^0.344.0",
-    "monaco-editor": "^0.52.0",
     "next": "^15.4.6",
     "next-auth": "^4.24.11",
     "next-themes": "^0.3.0",


### PR DESCRIPTION
## Summary
- switch the admin mail template editor from Monaco to CodeMirror, including the new extensions, editor lifecycle hooks, and snippet insertion helpers
- add the CodeMirror packages and drop the old Monaco dependencies so the project installs the new editor stack cleanly

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d3b706c3c48329b10e52cc93a029e0