### PR TITLE
Add expense author filter and totals

### DIFF
--- a/docs/expenses-service-reports-api.md
+++ b/docs/expenses-service-reports-api.md
@@ -6,7 +6,7 @@ Write operations require an authenticated admin user with the appropriate permis
 ## Expenses (`/api/expenses`)
 | Method | Description | Auth | Permission |
 | --- | --- | --- | --- |
-| GET `/api/expenses` | Paginated list of expenses. Supports `type`, `car_id`, `is_recurring`, plus `?include=car,recurrence`. | Admin | `expenses.view` |
+| GET `/api/expenses` | Paginated list of expenses. Supports `type`, `car_id`, `is_recurring`, `created_by`, plus `?include=car,recurrence,createdBy`. | Admin | `expenses.view` |
 | GET `/api/expenses/{id}` | Retrieve a single expense with optional relationships. | Admin | `expenses.view` |
 | POST `/api/expenses` | Create a new expense (fields below). | Admin | `expenses.create` |
 | PUT/PATCH `/api/expenses/{id}` | Update an expense. Recurring chains propagate updates forward. | Admin | `expenses.update` |
@@ -20,6 +20,7 @@ Write operations require an authenticated admin user with the appropriate permis
 - `car_id` – optional, links the expense to a car (`dacars_cars.id`).
 - `is_recurring` – boolean flag (default `false`). When `true` the expense repeats monthly.
 - `ends_on` – optional ISO date. When provided, recurring generation stops after that month.
+- Responses include `created_by` (the admin ID) and, when using `?include=createdBy`, a `created_by_user` object with the author's profile (name, email, username).
 
 ### Recurring behaviour
 - Setting `is_recurring = true` stores a template in `dacars_expense_recurrences` and instantly creates one entry per month up to the current month.
@@ -50,6 +51,7 @@ Write operations require an authenticated admin user with the appropriate permis
     "car_id": null,
     "spent_at": "2025-01-10",
     "is_recurring": true,
+    "created_by": 4,
     "created_at": "2025-01-10T09:00:00+02:00",
     "updated_at": "2025-01-10T09:00:00+02:00",
     "recurrence": {
@@ -59,6 +61,12 @@ Write operations require an authenticated admin user with the appropriate permis
       "starts_on": "2025-01-10",
       "ends_on": "2025-12-31",
       "last_generated_period": "2025-03-01"
+    },
+    "created_by_user": {
+      "id": 4,
+      "first_name": "Irina",
+      "last_name": "Popescu",
+      "email": "irina@dacars.ro"
     }
   }
 }

--- a/types/expense.ts
+++ b/types/expense.ts
@@ -1,5 +1,16 @@
 import type { CarLookup } from "@/types/car";
 
+export interface ExpenseAuthor {
+  id?: number | string | null;
+  first_name?: string | null;
+  last_name?: string | null;
+  name?: string | null;
+  full_name?: string | null;
+  email?: string | null;
+  username?: string | null;
+  [key: string]: unknown;
+}
+
 export type ExpenseType =
   | "spalat"
   | "parcare"
@@ -30,6 +41,8 @@ export interface Expense {
   ends_on?: string | null;
   created_at?: string | null;
   updated_at?: string | null;
+  created_by?: number | string | null;
+  created_by_user?: ExpenseAuthor | null;
   recurrence?: ExpenseRecurrence | null;
   car?: CarLookup | null;
   [key: string]: unknown;
@@ -43,6 +56,7 @@ export interface ExpenseListParams {
   type?: ExpenseType | string;
   car_id?: number | string;
   is_recurring?: boolean | number | string;
+  created_by?: number | string;
   include?: string | readonly string[];
   [key: string]: unknown;
 }


### PR DESCRIPTION
## Summary
- allow admin fleet expense list to filter by author, show the author column/details, and display a filtered total
- normalize expense creator data and persist known authors for selection while updating type definitions
- document the new `created_by` filter/include in the expenses API reference

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d58c19b7188329aa8232d87ae05b36