### PR TITLE
Show expiring car documents in admin dashboard

### DIFF
--- a/docs/admin-fleet-api.md
+++ b/docs/admin-fleet-api.md
@@ -10,6 +10,7 @@ Admin-only endpoints for managing cars, their categories, colours, and translate
 | DELETE | `/api/cars/{id}` | Remove a car (soft-delete if your model uses `SoftDeletes`). | `cars.delete` |
 | POST | `/api/cars/{id}/sync-categories` | Replace the car-category pivot set. | `cars.sync_categories` |
 | POST | `/api/cars/{id}/sync-colors` | Replace the car-colour pivot set. | `cars.sync_colors` |
+| GET | `/api/admin/cars/expiring-documents` | List cars whose technical documents expire within `within_days` (default 7). | `cars.view` |
 | GET | `/api/cars/{id}/translations` | List stored translations for `name`, `description`, `content`. | `cars.view_translations` |
 | PUT | `/api/cars/{id}/translations/{lang}` | Upsert a translation row. | `cars.update_translations` |
 | DELETE | `/api/cars/{id}/translations/{lang}` | Delete a translation row. | `cars.delete_translations` |
@@ -109,6 +110,44 @@ Sends the same fields as `store`, but each rule becomes `sometimes`. Validation 
 
 ## DELETE `/api/cars/{id}`
 Returns `{ "deleted": true }` on success. If the model uses soft deletes the record remains in the database for restoration.
+
+---
+
+## GET `/api/admin/cars/expiring-documents`
+
+Returns the cars whose `itp_expires_at`, `rovinieta_expires_at`, or `insurance_expires_at` values occur within the next `within_days` days. By default the controller filters with `within_days=7`. The response mirrors the public car resource but only the identification and expiry fields are required by the dashboard.
+
+### Query parameters
+- `within_days` – optional positive integer. Overrides the default 7-day window.
+
+### Sample response
+```json
+{
+  "data": [
+    {
+      "id": 21,
+      "name": "Skoda Octavia Combi Style",
+      "license_plate": "B-55-SKO",
+      "itp_expires_at": "2025-02-20",
+      "rovinieta_expires_at": "2025-02-18",
+      "insurance_expires_at": "2025-02-15"
+    },
+    {
+      "id": 12,
+      "name": "Dacia Logan",
+      "license_plate": "B-99-LOG",
+      "itp_expires_at": null,
+      "rovinieta_expires_at": "2025-02-19",
+      "insurance_expires_at": null
+    }
+  ],
+  "meta": {
+    "count": 2,
+    "current_page": 1,
+    "per_page": 50
+  }
+}
+```
 
 ---
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -15,6 +15,8 @@ import type {
 } from "@/types/auth";
 import type {
     AdminBookingResource,
+    AdminExpiringCarDocumentsParams,
+    AdminExpiringDocumentCar,
     BookingContractResponse,
     CategoryPrice,
     CategoryPriceCalendar,
@@ -2445,6 +2447,23 @@ export class ApiClient {
         const query = searchParams.toString();
         return this.request<AdminCarsTotalMetrics>(
             `/admin/metrics/cars-total${query ? `?${query}` : ''}`,
+        );
+    }
+
+    async fetchAdminExpiringCarDocuments(
+        params: AdminExpiringCarDocumentsParams = {},
+    ): Promise<ApiListResult<AdminExpiringDocumentCar>> {
+        const searchParams = new URLSearchParams();
+        if (
+            typeof params.within_days === 'number' &&
+            Number.isFinite(params.within_days) &&
+            params.within_days > 0
+        ) {
+            searchParams.append('within_days', String(params.within_days));
+        }
+        const query = searchParams.toString();
+        return this.request<ApiListResult<AdminExpiringDocumentCar>>(
+            `/admin/cars/expiring-documents${query ? `?${query}` : ''}`,
         );
     }
 

--- a/types/admin.ts
+++ b/types/admin.ts
@@ -86,6 +86,24 @@ export interface AdminCar {
   partnerPercentage?: number | null;
 }
 
+export interface AdminExpiringCarDocumentsParams {
+  within_days?: number;
+}
+
+export interface AdminExpiringDocumentCar {
+  id?: number | string | null;
+  car_id?: number | string | null;
+  name?: string | null;
+  car_name?: string | null;
+  license_plate?: string | null;
+  licensePlate?: string | null;
+  plate?: string | null;
+  itp_expires_at?: string | null;
+  rovinieta_expires_at?: string | null;
+  insurance_expires_at?: string | null;
+  [key: string]: unknown;
+}
+
 export interface AdminCategory {
   id: number;
   name: string;


### PR DESCRIPTION
## Summary
- replace the mock recent reservations table with a table that lists cars whose ITP, rovinietă or insurance expire within seven days
- add the API client method and TypeScript types required to load cars with expiring documents
- document the new admin endpoint for expiring documents in the fleet management API guide

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d5ae69b5f08329acebffde6968b005