### PR TITLE
Align booking and wheel clients with latest API docs

### DIFF
--- a/app/admin/wheel-of-fortune/page.tsx
+++ b/app/admin/wheel-of-fortune/page.tsx
@@ -63,6 +63,34 @@ const DEFAULT_PRIZE_COLOR = "#1E7149";
 const DEFAULT_PRIZE_TYPE: WheelOfFortuneType =
     WHEEL_OF_FORTUNE_TYPES[0] ?? "percentage_discount";
 
+const MONTHS: { value: number; label: string }[] = [
+    { value: 1, label: "Ianuarie" },
+    { value: 2, label: "Februarie" },
+    { value: 3, label: "Martie" },
+    { value: 4, label: "Aprilie" },
+    { value: 5, label: "Mai" },
+    { value: 6, label: "Iunie" },
+    { value: 7, label: "Iulie" },
+    { value: 8, label: "August" },
+    { value: 9, label: "Septembrie" },
+    { value: 10, label: "Octombrie" },
+    { value: 11, label: "Noiembrie" },
+    { value: 12, label: "Decembrie" },
+];
+
+const formatActiveMonths = (values?: number[] | null) => {
+    if (!Array.isArray(values) || values.length === 0) {
+        return null;
+    }
+    const labels = values
+        .map((value) => MONTHS.find((month) => month.value === value)?.label ?? null)
+        .filter((label): label is string => Boolean(label));
+    if (labels.length === 0) {
+        return null;
+    }
+    return labels.join(", ");
+};
+
 const amountFormatter = new Intl.NumberFormat("ro-RO", {
     maximumFractionDigits: 2,
     minimumFractionDigits: 0,
@@ -266,16 +294,25 @@ const mapPeriod = (item: unknown): WheelOfFortunePeriod | null => {
     const normalizedActive =
         typeof isActiveRaw !== "undefined" ? parseBoolean(isActiveRaw) : undefined;
 
+    const activeMonths = Array.isArray(item.active_months)
+        ? item.active_months
+              .map((entry) => Number(entry))
+              .filter((entry) => Number.isFinite(entry) && entry >= 1 && entry <= 12)
+        : [];
+
     return {
         id,
         name,
         start_at: typeof start === "string" ? start : null,
         end_at: typeof end === "string" ? end : null,
+        starts_at: typeof start === "string" ? start : null,
+        ends_at: typeof end === "string" ? end : null,
         active: normalizedActive,
         is_active: normalizedActive,
         description: typeof item.description === "string" ? item.description : null,
         created_at: typeof item.created_at === "string" ? item.created_at : null,
         updated_at: typeof item.updated_at === "string" ? item.updated_at : null,
+        active_months: activeMonths.length > 0 ? activeMonths : null,
     };
 };
 
@@ -378,6 +415,7 @@ export default function WheelOfFortuneAdminPage() {
         end: "",
         isActive: true,
         description: "",
+        activeMonths: [] as number[],
     });
 
     const [isPrizeModalOpen, setIsPrizeModalOpen] = useState(false);
@@ -506,6 +544,7 @@ export default function WheelOfFortuneAdminPage() {
             end: "",
             isActive: periods.length === 0,
             description: "",
+            activeMonths: [],
         });
         setPeriodFormError(null);
         setIsPeriodModalOpen(true);
@@ -519,6 +558,11 @@ export default function WheelOfFortuneAdminPage() {
             end: toDateInputValue(period.end_at),
             isActive: isPeriodActive(period),
             description: period.description ?? "",
+            activeMonths: Array.isArray(period.active_months)
+                ? period.active_months
+                      .map((value) => Number(value))
+                      .filter((value) => Number.isFinite(value) && value >= 1 && value <= 12)
+                : [],
         });
         setPeriodFormError(null);
         setIsPeriodModalOpen(true);
@@ -549,6 +593,12 @@ export default function WheelOfFortuneAdminPage() {
         setPeriodFormError(null);
         setPeriodSaving(true);
 
+        const normalizedMonths = Array.from(
+            new Set(periodForm.activeMonths.map((value) => Number(value))),
+        )
+            .filter((value) => Number.isFinite(value) && value >= 1 && value <= 12)
+            .sort((a, b) => a - b);
+
         const payload = {
             name: trimmedName,
             start_at: periodForm.start || undefined,
@@ -556,6 +606,7 @@ export default function WheelOfFortuneAdminPage() {
             active: periodForm.isActive,
             is_active: periodForm.isActive,
             description: periodForm.description.trim() || undefined,
+            active_months: normalizedMonths,
         };
 
         try {
@@ -922,6 +973,7 @@ export default function WheelOfFortuneAdminPage() {
                     <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
                         {periods.map((period) => {
                             const isSelected = period.id === selectedPeriodId;
+                            const activeMonthsLabel = formatActiveMonths(period.active_months);
                             return (
                                 <div
                                     key={period.id}
@@ -946,6 +998,11 @@ export default function WheelOfFortuneAdminPage() {
                                             <p className="mt-2 text-sm text-gray-600">
                                                 {formatDateRange(period.start_at, period.end_at)}
                                             </p>
+                                            {activeMonthsLabel && (
+                                                <p className="mt-1 text-xs text-gray-500">
+                                                    Lunile eligibile: {activeMonthsLabel}
+                                                </p>
+                                            )}
                                         </div>
                                         {isPeriodActive(period) ? (
                                             <span className="inline-flex items-center gap-1 rounded-full bg-jade/10 px-3 py-1 text-xs font-semibold text-jade">
@@ -1136,6 +1193,46 @@ export default function WheelOfFortuneAdminPage() {
                                     setPeriodForm((prev) => ({ ...prev, end: event.target.value }))
                                 }
                             />
+                        </div>
+                    </div>
+
+                    <div className="space-y-2">
+                        <span className="text-sm font-medium text-gray-700">Luni eligibile</span>
+                        <p className="text-xs text-gray-500">
+                            Selectează lunile pentru care premiile din această perioadă sunt valabile. Dacă nu selectezi nimic,
+                            premiile vor fi eligibile în orice lună.
+                        </p>
+                        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                            {MONTHS.map((month) => {
+                                const isChecked = periodForm.activeMonths.includes(month.value);
+                                return (
+                                    <label
+                                        key={month.value}
+                                        className="flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm"
+                                    >
+                                        <input
+                                            type="checkbox"
+                                            className="h-4 w-4 rounded border-gray-300 text-berkeley focus:ring-berkeley"
+                                            checked={isChecked}
+                                            onChange={(event) => {
+                                                setPeriodForm((prev) => {
+                                                    const next = new Set(prev.activeMonths);
+                                                    if (event.target.checked) {
+                                                        next.add(month.value);
+                                                    } else {
+                                                        next.delete(month.value);
+                                                    }
+                                                    return {
+                                                        ...prev,
+                                                        activeMonths: Array.from(next).sort((a, b) => a - b),
+                                                    };
+                                                });
+                                            }}
+                                        />
+                                        {month.label}
+                                    </label>
+                                );
+                            })}
                         </div>
                     </div>
 

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -988,6 +988,9 @@ const ReservationPage = () => {
 
     const wheelPrizeDiscount = useMemo(() => {
         if (!hasWheelPrize || !wheelPrizeRecord) return 0;
+        if (quoteResult?.wheel_prize?.eligible === false) {
+            return 0;
+        }
         if (typeof quoteResult?.wheel_prize_discount === "number") {
             const normalized = Math.round(quoteResult.wheel_prize_discount * 100) / 100;
             return normalized > 0 ? normalized : 0;
@@ -1002,6 +1005,7 @@ const ReservationPage = () => {
         hasWheelPrize,
         quoteResult?.price_per_day,
         quoteResult?.total_before_wheel_prize,
+        quoteResult?.wheel_prize?.eligible,
         quoteResult?.wheel_prize_discount,
         wheelPrizeRecord,
     ]);
@@ -1014,10 +1018,17 @@ const ReservationPage = () => {
     }, [hasWheelPrize, t, wheelPrizeExpiryLabel]);
     const wheelPrizeSavingsMessage = useMemo(() => {
         if (!wheelPrizeApplied || wheelPrizeDiscount <= 0) return null;
+        if (quoteResult?.wheel_prize?.eligible === false) return null;
         return t("wheelPrize.savings", {
             values: { amount: formatCurrency(wheelPrizeDiscount) },
         });
-    }, [formatCurrency, t, wheelPrizeApplied, wheelPrizeDiscount]);
+    }, [
+        formatCurrency,
+        quoteResult?.wheel_prize?.eligible,
+        t,
+        wheelPrizeApplied,
+        wheelPrizeDiscount,
+    ]);
     const normalizedCouponCode = formData.coupon_code.trim();
 
     useEffect(() => {
@@ -1079,6 +1090,7 @@ const ReservationPage = () => {
                         prize_id: prizeId,
                         wheel_of_fortune_id: wheelPrizeRecord.wheel_of_fortune_id,
                         discount_value: wheelPrizeDiscountForRequest,
+                        eligible: true,
                     };
                 } else {
                     payload.wheel_prize_discount = 0;
@@ -1156,6 +1168,7 @@ const ReservationPage = () => {
         : estimatedPerDayPrice;
     const quoteCouponType = quoteResult?.coupon_type ?? discountStatus?.couponType ?? null;
     const quoteWheelPrizeDetails = quoteResult?.wheel_prize ?? null;
+    const isQuoteWheelPrizeEligible = quoteWheelPrizeDetails?.eligible !== false;
 
     const handleDiscountCodeValidation = async (
         force = false,
@@ -1368,6 +1381,7 @@ const ReservationPage = () => {
                 amount_label: wheelPrizeAmountLabel,
                 expires_at: wheelPrizeRecord.expires_at,
                 discount_value: wheelPrizeDiscountValue,
+                eligible: true,
             }
             : null;
 
@@ -1375,6 +1389,7 @@ const ReservationPage = () => {
             ? {
                 ...quoteWheelPrizeDetails,
                 discount_value: wheelPrizeDiscountValue,
+                eligible: quoteWheelPrizeDetails.eligible ?? true,
             }
             : fallbackWheelPrizeDetails;
 

--- a/components/admin/BookingForm.tsx
+++ b/components/admin/BookingForm.tsx
@@ -544,10 +544,19 @@ const BookingForm: React.FC<BookingFormProps> = ({
             ? Math.round(totalBeforeWheelPrizeValue * 100) / 100
             : null;
     const hasWheelPrize = Boolean(wheelPrizeSummary);
-    const hasWheelPrizeDiscount = wheelPrizeDiscountDisplay > 0;
+    const wheelPrizeEligible = wheelPrizeSummary?.eligible !== false;
+    const hasWheelPrizeDiscount = wheelPrizeDiscountDisplay > 0 && wheelPrizeEligible;
+    const wheelPrizeEligibilityWarning = hasWheelPrize && !wheelPrizeEligible
+        ? "Premiul nu este eligibil pentru intervalul curent."
+        : null;
     const wheelPrizeTitle = hasWheelPrize
         ? wheelPrizeSummary?.title ?? "Premiu DaCars"
         : "—";
+    const offersDiscountValue = toOptionalNumber(bookingInfo.offers_discount) ?? 0;
+    const depositWaived = bookingInfo.deposit_waived === true;
+    const appliedOffersList = Array.isArray(bookingInfo.applied_offers)
+        ? bookingInfo.applied_offers
+        : [];
 
     const handleUpdateBooking = async () => {
         if (!bookingInfo || bookingInfo.id == null) {
@@ -1088,6 +1097,11 @@ const BookingForm: React.FC<BookingFormProps> = ({
                                 <span className="text-right ms-2">{wheelPrizeAmountLabel}</span>
                             </div>
                         )}
+                        {wheelPrizeEligibilityWarning && (
+                            <div className="font-dm-sans text-xs text-amber-600 border-b border-b-1 mb-1">
+                                {wheelPrizeEligibilityWarning}
+                            </div>
+                        )}
                         {hasWheelPrizeDiscount && (
                             <div className="font-dm-sans text-sm flex justify-between border-b border-b-1 mb-1">
                                 <span>Reducere premiu:</span>
@@ -1100,6 +1114,18 @@ const BookingForm: React.FC<BookingFormProps> = ({
                                 <span>{wheelPrizeExpiryLabel}</span>
                             </div>
                         )}
+                        {offersDiscountValue > 0 && (
+                            <div className="font-dm-sans text-sm flex justify-between border-b border-b-1 mb-1">
+                                <span>Reduceri campanii:</span>
+                                <span>-{Math.round(offersDiscountValue * 100) / 100}€</span>
+                            </div>
+                        )}
+                        {depositWaived && (
+                            <div className="font-dm-sans text-xs text-jade flex justify-between border-b border-b-1 mb-1">
+                                <span>Garanție:</span>
+                                <span>Eliminată prin promoție</span>
+                            </div>
+                        )}
                         {bookingInfo.advance_payment > 0 && (
                             <div className="font-dm-sans text-sm flex justify-between border-b border-b-1 mb-1">
                                 <span>Avans:</span> <span>{bookingInfo.advance_payment}€</span>
@@ -1109,6 +1135,23 @@ const BookingForm: React.FC<BookingFormProps> = ({
                             <span>Total:</span>
                             <span>{originalTotal}€</span>
                         </div>
+                        {appliedOffersList.length > 0 && (
+                            <div className="mt-3">
+                                <span className="font-dm-sans text-xs font-semibold text-gray-600 uppercase">
+                                    Oferte aplicate
+                                </span>
+                                <ul className="mt-1 list-disc space-y-1 ps-5 text-xs text-gray-600">
+                                    {appliedOffersList.map((offer) => (
+                                        <li key={offer.id}>
+                                            <span className="font-medium text-gray-700">{offer.title}</span>
+                                            {offer.discount_label && (
+                                                <span className="ms-1 text-emerald-600">{offer.discount_label}</span>
+                                            )}
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        )}
                                 {discount !== 0 && discountedTotal > 0 && (
                                     <div className="font-dm-sans text-sm">
                                         Detalii discount:

--- a/types/admin.ts
+++ b/types/admin.ts
@@ -1,6 +1,10 @@
 import type { ApiCar, CarLookup } from "@/types/car";
 import type { Offer, OfferIcon, OfferStatus } from "@/types/offer";
-import type { ReservationWheelPrizeSummary, ServiceStatus } from "@/types/reservation";
+import type {
+  ReservationAppliedOffer,
+  ReservationWheelPrizeSummary,
+  ServiceStatus,
+} from "@/types/reservation";
 
 export interface AdminReservation {
   id: string;
@@ -24,9 +28,12 @@ export interface AdminReservation {
   pricePerDay?: number;
   servicesPrice?: number;
   discount?: number;
+  offersDiscount?: number | null;
   totalBeforeWheelPrize?: number | null;
   wheelPrizeDiscount?: number | null;
   wheelPrize?: ReservationWheelPrizeSummary | null;
+  appliedOffers?: ReservationAppliedOffer[] | null;
+  depositWaived?: boolean | null;
   email?: string;
   days?: number;
   pickupTime?: string;
@@ -257,6 +264,9 @@ export interface AdminBookingResource {
   total_before_wheel_prize?: number | string | null;
   wheel_prize_discount?: number | string | null;
   wheel_prize?: ReservationWheelPrizeSummary | null;
+  offers_discount?: number | string | null;
+  deposit_waived?: boolean | number | string | null;
+  applied_offers?: ReservationAppliedOffer[] | null;
   discount?: number | string | null;
   discount_type?: string | null;
   location?: string | null;
@@ -328,6 +338,9 @@ export interface AdminBookingFormValues {
   total_before_wheel_prize: number | null;
   wheel_prize_discount: number;
   wheel_prize: ReservationWheelPrizeSummary | null;
+  offers_discount: number;
+  deposit_waived: boolean;
+  applied_offers: ReservationAppliedOffer[];
   discount_applied?: number | null;
   location?: string;
   tax_amount?: number;
@@ -373,6 +386,9 @@ export const createEmptyBookingForm = (): AdminBookingFormValues => ({
   total_before_wheel_prize: null,
   wheel_prize_discount: 0,
   wheel_prize: null,
+  offers_discount: 0,
+  deposit_waived: false,
+  applied_offers: [],
   discount_applied: null,
   location: "",
   tax_amount: 0,

--- a/types/reservation.ts
+++ b/types/reservation.ts
@@ -74,6 +74,7 @@ export interface ReservationWheelPrizeSummary {
   description?: string | null;
   amount_label?: string | null;
   expires_at?: string | null;
+  eligible?: boolean | null;
   discount_value: number;
 }
 
@@ -82,6 +83,7 @@ export interface ReservationWheelPrizePayload {
   wheel_of_fortune_id?: number | string | null;
   wheel_of_fortune_prize_id?: number | string | null;
   discount_value: number | string;
+  eligible?: boolean | null;
   [key: string]: unknown;
 }
 

--- a/types/wheel.ts
+++ b/types/wheel.ts
@@ -42,6 +42,7 @@ export interface WheelOfFortuneSlice {
   type: WheelOfFortuneType;
   created_at?: string | null;
   updated_at?: string | null;
+  period?: WheelOfFortunePeriod | null;
 }
 
 export type WheelPrize = WheelOfFortuneSlice;
@@ -51,11 +52,15 @@ export interface WheelOfFortunePeriod {
   name: string;
   start_at?: string | null;
   end_at?: string | null;
+  starts_at?: string | null;
+  ends_at?: string | null;
   active?: boolean;
   is_active?: boolean;
   description?: string | null;
   created_at?: string | null;
   updated_at?: string | null;
+  active_months?: number[] | null;
+  wheel_of_fortunes?: WheelPrize[] | null;
 }
 
 export interface WheelOfFortunePrizePayload {


### PR DESCRIPTION
## Summary
- normalize admin booking tables and forms to the latest booking payloads, including wheel prize and applied offer metadata
- update wheel of fortune admin tools and public widget to support new period filtering, prize typing, and active month handling
- extend the shared API client and types with the new booking and wheel endpoints and response shapes from the refreshed docs

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d6eda963bc832995d38792fca819e8