### PR TITLE
Fix admin calendar mobile loading and add zoom controls

### DIFF
--- a/components/admin/CarRentalCalendar.tsx
+++ b/components/admin/CarRentalCalendar.tsx
@@ -1171,13 +1171,6 @@ const CarRentalCalendar: React.FC = () => {
                                             {car.model && (
                                                 <p className="text-xs text-gray-600 truncate">{car.model}</p>
                                             )}
-                                            {(car.year || car.type) && (
-                                                <div className="mt-1 flex items-center space-x-3 text-[11px] text-gray-500">
-                                                    {car.year && <span>{car.year}</span>}
-                                                    {car.type && car.year && <span>•</span>}
-                                                    {car.type && <span className="capitalize">{car.type}</span>}
-                                                </div>
-                                            )}
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
- parse booking dates more defensively so reservations load correctly on mobile browsers
- show each car's license plate as the primary label with the model underneath and localize calendar labels to Romanian
- add zoom controls to the admin calendar so the grid can be scaled on small screens

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d7c4dadc2083298116d8d629411a79