### PR TITLE
Corectează dimensiunea logo-ului din header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -107,11 +107,15 @@ const Header = () => {
     }`}>
       <div className="max-w-7xl mx-auto">
         <div className="flex justify-between items-center h-16 lg:h-20">
-            <Link href="/" className="flex items-center space-x-2 group" aria-label="DaCars — închirieri auto rapide și oneste">
+            <Link
+                href="/"
+                className="flex h-full items-center space-x-2 group"
+                aria-label="DaCars — închirieri auto rapide și oneste"
+            >
                     {/* Eager + fetchpriority=high ajută LCP pe homepage */}
                     <Image
                         src="/images/logo-308x154.webp"
-                        className="relative w-auto"
+                        className="relative h-10 w-auto lg:h-12"
                         alt="DaCars logo"
                         width={466}
                         height={154}


### PR DESCRIPTION
## Summary
- restricționează înălțimea siglei din header pentru a nu depăși bara de navigație
- aliniază link-ul logo-ului pe înălțimea header-ului pentru a elimina aria de click extra

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8e55e44388329adaab00224ecac72