### PR TITLE
Handle optional pagination metadata in activity tracking

### DIFF
--- a/components/admin/activity-tracking/ActivityTrackingManager.tsx
+++ b/components/admin/activity-tracking/ActivityTrackingManager.tsx
@@ -749,11 +749,12 @@ const ActivityTrackingManager = () => {
       const meta = deriveMeta(listResponse);
 
       let records = extractList(listResponse);
-      const hasMorePages = typeof meta?.last_page === "number" && meta.last_page > 1;
+      const lastPage = typeof meta?.last_page === "number" ? meta.last_page : null;
+      const hasMorePages = lastPage !== null && lastPage > 1;
 
-      if (hasMorePages) {
+      if (hasMorePages && lastPage !== null) {
         const additionalResponses = await Promise.all(
-          Array.from({ length: meta.last_page - 1 }, (_, index) =>
+          Array.from({ length: lastPage - 1 }, (_, index) =>
             apiClient.getActivities({ ...params, page: index + 2 }),
           ),
         );


### PR DESCRIPTION
## Summary
- ensure the activity tracking manager handles missing pagination metadata when aggregating activity pages
- reuse the resolved last page count when requesting additional activity pages

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9976237748329b491544b69a4bcb2