### PR TITLE
Lazy load Wheel of Fortune popup on homepage

### DIFF
--- a/components/home/HomePageClient.tsx
+++ b/components/home/HomePageClient.tsx
@@ -8,13 +8,17 @@ import FleetSection from "@/components/FleetSection";
 import HeroSection from "@/components/HeroSection";
 import OffersSection from "@/components/OffersSection";
 import ProcessSection from "@/components/ProcessSection";
-import WheelOfFortune from "@/components/WheelOfFortune";
 import apiClient from "@/lib/api";
 import { extractArray, isPeriodActive, mapPeriod } from "@/lib/wheelNormalization";
 import { useBooking } from "@/context/useBooking";
 import type { WheelOfFortunePeriod } from "@/types/wheel";
 
 const ElfsightWidget = dynamic(() => import("@/components/ElfsightWidget"), {
+    ssr: false,
+});
+
+const LazyWheelOfFortune = dynamic(() => import("@/components/WheelOfFortune"), {
+    loading: () => null,
     ssr: false,
 });
 
@@ -172,7 +176,7 @@ const HomePageClient = () => {
             <ContactSection />
 
             {showWheelPopup && !periodError && (
-                <WheelOfFortune
+                <LazyWheelOfFortune
                     isPopup={true}
                     onClose={handleWheelClose}
                 />


### PR DESCRIPTION
## Summary
- defer the Wheel of Fortune popup to a lazy client chunk so it only loads when needed

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d999fe1a6883299256c1dc0107a802