### PR TITLE
Optimize initial CSS delivery for faster first render

### DIFF
--- a/app/global-styles.tsx
+++ b/app/global-styles.tsx
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { JSX } from "react";
+
+const isProduction = process.env.NODE_ENV === "production";
+
+if (!isProduction) {
+  void import("./globals.css");
+}
+
+const tailwindBundlePath = path.join(process.cwd(), "public", "tailwind.css");
+let inlineTailwindCss: string | null = null;
+
+if (isProduction) {
+  try {
+    inlineTailwindCss = fs.readFileSync(tailwindBundlePath, "utf8");
+  } catch (error) {
+    console.error("Nu s-a putut citi fișierul CSS optimizat:", error);
+  }
+}
+
+const asyncCssScript = `(() => {
+  const link = document.querySelector('link[data-async-css="tailwind"]');
+  if (!link || !(link instanceof HTMLLinkElement)) return;
+  if (link.media === 'all') return;
+  const critical = document.getElementById('critical-tailwind');
+  const enable = () => {
+    link.media = 'all';
+    if (critical && critical.parentNode) {
+      critical.parentNode.removeChild(critical);
+    }
+  };
+  link.addEventListener('load', enable, { once: true });
+  if (link.sheet) {
+    enable();
+  }
+})();`;
+
+const noscriptStyles = '<link rel="stylesheet" href="/tailwind.css" />';
+
+export function GlobalStyles(): JSX.Element | null {
+  if (!isProduction) {
+    return null;
+  }
+
+  if (!inlineTailwindCss) {
+    return (
+      // eslint-disable-next-line @next/next/no-css-tags
+      <link rel="stylesheet" href="/tailwind.css" />
+    );
+  }
+
+  return (
+    <>
+      <style
+        id="critical-tailwind"
+        dangerouslySetInnerHTML={{ __html: inlineTailwindCss }}
+      />
+      {/* eslint-disable-next-line @next/next/no-css-tags */}
+      <link rel="preload" as="style" href="/tailwind.css" />
+      {/* eslint-disable-next-line @next/next/no-css-tags */}
+      <link
+        rel="stylesheet"
+        href="/tailwind.css"
+        media="print"
+        data-async-css="tailwind"
+      />
+      <script dangerouslySetInnerHTML={{ __html: asyncCssScript }} />
+      <noscript dangerouslySetInnerHTML={{ __html: noscriptStyles }} />
+    </>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,7 @@ import { LocaleProvider } from "@/context/LocaleContext";
 import { DM_Sans, Poppins } from "next/font/google";
 import { buildMetadata } from "@/lib/seo/meta";
 import { siteMetadata } from "@/lib/seo/siteMetadata";
-import "./globals.css";
+import { GlobalStyles } from "./global-styles";
 
 const poppins = Poppins({
   subsets: ["latin"],
@@ -55,6 +55,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ro" className={`${poppins.variable} ${dmSans.variable}`}>
       <head>
+        <GlobalStyles />
         <link
           rel="preload"
           as="image"

--- a/types/css.d.ts
+++ b/types/css.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";


### PR DESCRIPTION
## Summary
- inline the prebuilt Tailwind bundle during SSR and asynchronously hydrate the full stylesheet in production through a new `GlobalStyles` helper
- update the app root layout to consume the optimized loader while preserving the development CSS import path

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d9a8fd28d88329a562e7d33ce67dd2