### PR TITLE
Cache locale resolution for home SEO metadata

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_LOCALE, type Locale } from "@/lib/i18n/config";
 import { resolveRequestLocale } from "@/lib/i18n/server";
 import { buildMetadata } from "@/lib/seo/meta";
 import { breadcrumb, organization, website } from "@/lib/seo/jsonld";
+import { cache } from "react";
 
 type HomeSeoCopy = {
     metaTitle: string;
@@ -55,11 +56,11 @@ const HOME_SEO_COPY: Record<Locale, HomeSeoCopy> = {
 const FALLBACK_LOCALE: Locale = DEFAULT_LOCALE;
 const HREFLANG_LOCALES = ["ro", "en", "it", "es", "fr", "de"] as const;
 
-const resolveHomeSeo = async () => {
+const resolveHomeSeo = cache(async () => {
     const locale = await resolveRequestLocale();
     const copy = HOME_SEO_COPY[locale] ?? HOME_SEO_COPY[FALLBACK_LOCALE];
     return { locale, copy };
-};
+});
 
 export async function generateMetadata(): Promise<Metadata> {
     const { locale, copy } = await resolveHomeSeo();


### PR DESCRIPTION
## Summary
- cache the locale resolution used for the home page SEO metadata to avoid duplicate header and cookie lookups

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68da451576e48329899f3f3b844b7875