### PR TITLE
Fix footer CLS by hydrating locale before render

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Header from "../components/Header";
 import Footer from "../components/Footer";
 import PageTransition from "../components/PageTransition";
+import Script from "next/script";
 import type { ReactNode } from "react";
 import { BookingProvider } from "@/context/BookingProvider";
 import { AuthProvider } from "@/context/AuthContext";
@@ -10,6 +11,7 @@ import { DM_Sans, Poppins } from "next/font/google";
 import { buildMetadata } from "@/lib/seo/meta";
 import { siteMetadata } from "@/lib/seo/siteMetadata";
 import { GlobalStyles } from "./global-styles";
+import { LOCALE_STORAGE_KEY } from "@/lib/i18n/config";
 
 const poppins = Poppins({
   subsets: ["latin"],
@@ -53,7 +55,12 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="ro" className={`${poppins.variable} ${dmSans.variable}`}>
+    <html
+      lang="ro"
+      data-locale="ro"
+      className={`${poppins.variable} ${dmSans.variable}`}
+      suppressHydrationWarning
+    >
       <head>
         <GlobalStyles />
         <link
@@ -90,6 +97,26 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         />
       </head>
       <body className="min-h-screen bg-white">
+        <Script id="prefill-locale" strategy="beforeInteractive">
+          {`
+            (function() {
+              try {
+                var stored = window.localStorage.getItem('${LOCALE_STORAGE_KEY}');
+                if (stored) {
+                  document.documentElement.lang = stored;
+                  document.documentElement.setAttribute('data-locale', stored);
+                  return;
+                }
+              } catch (error) {
+                console.warn('Nu am putut citi limba salvată înainte de hidratare', error);
+              }
+              var current = document.documentElement.getAttribute('data-locale');
+              if (!current) {
+                document.documentElement.setAttribute('data-locale', 'ro');
+              }
+            })();
+          `}
+        </Script>
         <LocaleProvider>
           <AuthProvider>
             <BookingProvider>

--- a/context/LocaleContext.tsx
+++ b/context/LocaleContext.tsx
@@ -21,19 +21,18 @@ type LocaleContextValue = {
 
 const LocaleContext = createContext<LocaleContextValue | undefined>(undefined);
 
-export const LocaleProvider = ({ children }: { children: ReactNode }) => {
-    const [locale, setLocaleState] = useState<Locale>(DEFAULT_LOCALE);
+const getInitialLocale = (): Locale => {
+    if (typeof document !== "undefined") {
+        const dataLocale = document.documentElement.getAttribute("data-locale");
+        if (dataLocale && isLocale(dataLocale)) {
+            return dataLocale;
+        }
+    }
+    return DEFAULT_LOCALE;
+};
 
-    useEffect(() => {
-        if (typeof window === "undefined") {
-            return;
-        }
-        const stored = window.localStorage.getItem(LOCALE_STORAGE_KEY);
-        if (stored && isLocale(stored)) {
-            setLocaleState(stored);
-            document.documentElement.lang = stored;
-        }
-    }, []);
+export const LocaleProvider = ({ children }: { children: ReactNode }) => {
+    const [locale, setLocaleState] = useState<Locale>(getInitialLocale);
 
     useEffect(() => {
         apiClient.setLanguage(locale);
@@ -44,6 +43,7 @@ export const LocaleProvider = ({ children }: { children: ReactNode }) => {
         if (typeof window !== "undefined") {
             window.localStorage.setItem(LOCALE_STORAGE_KEY, nextLocale);
             document.documentElement.lang = nextLocale;
+            document.documentElement.setAttribute("data-locale", nextLocale);
         }
     }, []);
 


### PR DESCRIPTION
## Summary
- preload the stored locale before hydration so localized copy renders without shifting layout
- initialize the locale context from the html data attribute and keep it synchronized when the locale changes

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68da4a3c67688329bb845cc8f748113f