### PR TITLE
Sync wheel prize metadata and document new booking payload fields

### DIFF
--- a/components/admin/BookingForm.tsx
+++ b/components/admin/BookingForm.tsx
@@ -359,6 +359,14 @@ const normalizeWheelPrizeSummary = (
     const discountValue = toOptionalNumber(
         raw.discount_value ?? raw.discount ?? (raw as { value?: unknown }).value,
     );
+    const discountValueDeposit =
+        toOptionalNumber((raw as { discount_value_deposit?: unknown }).discount_value_deposit) ??
+        toOptionalNumber((raw as { discount_deposit?: unknown }).discount_deposit) ??
+        (typeof discountValue === "number" ? discountValue : null);
+    const discountValueCasco =
+        toOptionalNumber((raw as { discount_value_casco?: unknown }).discount_value_casco) ??
+        toOptionalNumber((raw as { discount_casco?: unknown }).discount_casco) ??
+        (typeof discountValue === "number" ? discountValue : null);
     const description =
         typeof raw.description === "string" && raw.description.trim().length > 0
             ? raw.description
@@ -397,6 +405,10 @@ const normalizeWheelPrizeSummary = (
         amount_label: amountLabel,
         discount_value: typeof discountValue === "number" ? discountValue : 0,
         eligible,
+        discount_value_deposit:
+            typeof discountValueDeposit === "number" ? discountValueDeposit : null,
+        discount_value_casco:
+            typeof discountValueCasco === "number" ? discountValueCasco : null,
     };
 };
 
@@ -413,12 +425,21 @@ const sanitizeWheelPrizePayload = (
     }
     const wheelId = toOptionalNumber(prize.wheel_of_fortune_id);
     const discountValue = toOptionalNumber(prize.discount_value) ?? 0;
+    const discountValueDeposit =
+        toOptionalNumber(prize.discount_value_deposit) ?? discountValue;
+    const discountValueCasco = toOptionalNumber(prize.discount_value_casco) ?? discountValue;
     const payload: ReservationWheelPrizePayload = {
         prize_id: rawPrizeId,
         wheel_of_fortune_id: wheelId ?? null,
         wheel_of_fortune_prize_id: pivotId ?? null,
         discount_value: discountValue,
     };
+    if (discountValueDeposit != null) {
+        payload.discount_value_deposit = discountValueDeposit;
+    }
+    if (discountValueCasco != null) {
+        payload.discount_value_casco = discountValueCasco;
+    }
     if (typeof prize.eligible === "boolean") {
         payload.eligible = prize.eligible;
     }
@@ -475,14 +496,65 @@ const normalizeAppliedOfferEntry = (raw: unknown): ReservationAppliedOffer | nul
             : typeof (raw as { badge?: unknown }).badge === "string"
                 ? String((raw as { badge: unknown }).badge)
                 : null;
+    const percentDeposit = toOptionalNumber(
+        (raw as { percent_discount_deposit?: unknown }).percent_discount_deposit,
+    );
+    const percentCasco = toOptionalNumber(
+        (raw as { percent_discount_casco?: unknown }).percent_discount_casco,
+    );
+    const fixedDeposit = toOptionalNumber((raw as { fixed_discount_deposit?: unknown }).fixed_discount_deposit);
+    const fixedCasco = toOptionalNumber((raw as { fixed_discount_casco?: unknown }).fixed_discount_casco);
+    const fixedDepositApplied = toOptionalNumber(
+        (raw as { fixed_discount_deposit_applied?: unknown }).fixed_discount_deposit_applied,
+    );
+    const fixedCascoApplied = toOptionalNumber(
+        (raw as { fixed_discount_casco_applied?: unknown }).fixed_discount_casco_applied,
+    );
+    const discountAmountDeposit = toOptionalNumber(
+        (raw as { discount_amount_deposit?: unknown }).discount_amount_deposit,
+    );
+    const discountAmountCasco = toOptionalNumber(
+        (raw as { discount_amount_casco?: unknown }).discount_amount_casco,
+    );
+    const discountAmount = toOptionalNumber((raw as { discount_amount?: unknown }).discount_amount);
 
-    return {
+    const normalized: ReservationAppliedOffer = {
         id,
         title: titleSource,
         offer_type: offerType,
         offer_value: offerValue,
         discount_label: discountLabel,
     };
+
+    if (percentDeposit != null) {
+        normalized.percent_discount_deposit = percentDeposit;
+    }
+    if (percentCasco != null) {
+        normalized.percent_discount_casco = percentCasco;
+    }
+    if (fixedDeposit != null) {
+        normalized.fixed_discount_deposit = fixedDeposit;
+    }
+    if (fixedCasco != null) {
+        normalized.fixed_discount_casco = fixedCasco;
+    }
+    if (fixedDepositApplied != null) {
+        normalized.fixed_discount_deposit_applied = fixedDepositApplied;
+    }
+    if (fixedCascoApplied != null) {
+        normalized.fixed_discount_casco_applied = fixedCascoApplied;
+    }
+    if (discountAmountDeposit != null) {
+        normalized.discount_amount_deposit = discountAmountDeposit;
+    }
+    if (discountAmountCasco != null) {
+        normalized.discount_amount_casco = discountAmountCasco;
+    }
+    if (discountAmount != null) {
+        normalized.discount_amount = discountAmount;
+    }
+
+    return normalized;
 };
 
 const normalizeAppliedOffers = (raw: unknown): ReservationAppliedOffer[] => {
@@ -526,6 +598,44 @@ const sanitizeAppliedOffersPayload = (
                 offer_value: offer.offer_value ?? null,
                 discount_label: offer.discount_label ?? null,
             };
+            const percentDeposit = toOptionalNumber(offer.percent_discount_deposit);
+            const percentCasco = toOptionalNumber(offer.percent_discount_casco);
+            const fixedDeposit = toOptionalNumber(offer.fixed_discount_deposit);
+            const fixedCasco = toOptionalNumber(offer.fixed_discount_casco);
+            const fixedDepositApplied = toOptionalNumber(offer.fixed_discount_deposit_applied);
+            const fixedCascoApplied = toOptionalNumber(offer.fixed_discount_casco_applied);
+            const discountAmountDeposit = toOptionalNumber(offer.discount_amount_deposit);
+            const discountAmountCasco = toOptionalNumber(offer.discount_amount_casco);
+            const discountAmount = toOptionalNumber(offer.discount_amount);
+
+            if (percentDeposit != null) {
+                normalized.percent_discount_deposit = percentDeposit;
+            }
+            if (percentCasco != null) {
+                normalized.percent_discount_casco = percentCasco;
+            }
+            if (fixedDeposit != null) {
+                normalized.fixed_discount_deposit = fixedDeposit;
+            }
+            if (fixedCasco != null) {
+                normalized.fixed_discount_casco = fixedCasco;
+            }
+            if (fixedDepositApplied != null) {
+                normalized.fixed_discount_deposit_applied = fixedDepositApplied;
+            }
+            if (fixedCascoApplied != null) {
+                normalized.fixed_discount_casco_applied = fixedCascoApplied;
+            }
+            if (discountAmountDeposit != null) {
+                normalized.discount_amount_deposit = discountAmountDeposit;
+            }
+            if (discountAmountCasco != null) {
+                normalized.discount_amount_casco = discountAmountCasco;
+            }
+            if (discountAmount != null) {
+                normalized.discount_amount = discountAmount;
+            }
+
             return normalized;
         })
         .filter((entry): entry is ReservationAppliedOffer => entry != null);
@@ -632,9 +742,7 @@ const buildQuotePayload = (
     }
 
     const wheelPrizeSummary = values.wheel_prize ?? null;
-    const explicitWheelPrizeId = toOptionalNumber(
-        (values as { wheel_of_fortune_prize_id?: unknown }).wheel_of_fortune_prize_id,
-    );
+    const explicitWheelPrizeId = toOptionalNumber(values.wheel_of_fortune_prize_id);
     const wheelPrizeId =
         explicitWheelPrizeId ??
         toOptionalNumber(wheelPrizeSummary?.wheel_of_fortune_prize_id) ??
@@ -663,6 +771,11 @@ const buildQuotePayload = (
     const offersDiscount = toOptionalNumber(values.offers_discount);
     if (offersDiscount != null) {
         payload.offers_discount = offersDiscount;
+    }
+
+    const offerFixedDiscount = toOptionalNumber(values.offer_fixed_discount);
+    if (offerFixedDiscount != null) {
+        payload.offer_fixed_discount = offerFixedDiscount;
     }
 
     if (values.deposit_waived === true) {
@@ -855,6 +968,11 @@ const buildBookingUpdatePayload = (
         payload.offers_discount = offersDiscount;
     }
 
+    const offerFixedDiscount = toOptionalNumber(values.offer_fixed_discount);
+    if (offerFixedDiscount != null) {
+        payload.offer_fixed_discount = offerFixedDiscount;
+    }
+
     const appliedOffersPayload = sanitizeAppliedOffersPayload(values.applied_offers);
     payload.applied_offers = appliedOffersPayload ?? [];
 
@@ -971,6 +1089,12 @@ const BookingForm: React.FC<BookingFormProps> = ({
                         typeof prize.title === "string" && prize.title.trim().length > 0
                             ? prize.title.trim()
                             : `Premiu #${prizeId}`;
+                    const discountValueDeposit =
+                        toOptionalNumber((prize as { discount_value_deposit?: unknown }).discount_value_deposit) ??
+                        toOptionalNumber((prize as { discount_deposit?: unknown }).discount_deposit);
+                    const discountValueCasco =
+                        toOptionalNumber((prize as { discount_value_casco?: unknown }).discount_value_casco) ??
+                        toOptionalNumber((prize as { discount_casco?: unknown }).discount_casco);
                     const summary: ReservationWheelPrizeSummary = {
                         wheel_of_fortune_id: prize.period_id ?? period.id ?? null,
                         prize_id: prizeId,
@@ -981,6 +1105,18 @@ const BookingForm: React.FC<BookingFormProps> = ({
                         description: prize.description ?? null,
                         amount_label: null,
                         discount_value: typeof prize.amount === "number" ? prize.amount : 0,
+                        discount_value_deposit:
+                            typeof discountValueDeposit === "number"
+                                ? discountValueDeposit
+                                : typeof prize.amount === "number"
+                                    ? prize.amount
+                                    : null,
+                        discount_value_casco:
+                            typeof discountValueCasco === "number"
+                                ? discountValueCasco
+                                : typeof prize.amount === "number"
+                                    ? prize.amount
+                                    : null,
                         eligible: true,
                     };
                     return {
@@ -1003,7 +1139,7 @@ const BookingForm: React.FC<BookingFormProps> = ({
         );
         const currentPrizeId = bookingInfo
             ? toOptionalNumber(
-                  (bookingInfo as { wheel_of_fortune_prize_id?: unknown }).wheel_of_fortune_prize_id ??
+                  bookingInfo.wheel_of_fortune_prize_id ??
                       bookingInfo.wheel_prize?.wheel_of_fortune_prize_id ??
                       bookingInfo.wheel_prize?.prize_id,
               )
@@ -1081,7 +1217,7 @@ const BookingForm: React.FC<BookingFormProps> = ({
     const selectedWheelPrizeValue = useMemo(() => {
         const prizeId = bookingInfo
             ? toOptionalNumber(
-                  (bookingInfo as { wheel_of_fortune_prize_id?: unknown }).wheel_of_fortune_prize_id ??
+                  bookingInfo.wheel_of_fortune_prize_id ??
                       bookingInfo.wheel_prize?.wheel_of_fortune_prize_id ??
                       bookingInfo.wheel_prize?.prize_id,
               )
@@ -1189,10 +1325,23 @@ const BookingForm: React.FC<BookingFormProps> = ({
                         typeof data.offers_discount === "number"
                             ? data.offers_discount
                             : prev.offers_discount ?? 0;
+                    const normalizedOfferFixedDiscount =
+                        typeof data.offer_fixed_discount === "number"
+                            ? data.offer_fixed_discount
+                            : typeof prev.offer_fixed_discount === "number"
+                                ? prev.offer_fixed_discount
+                                : 0;
                     const normalizedDepositWaived =
                         typeof data.deposit_waived === "boolean"
                             ? data.deposit_waived
                             : prev.deposit_waived ?? false;
+                    const normalizedWheelPrizeId =
+                        toOptionalNumber(
+                            (data as { wheel_of_fortune_prize_id?: unknown }).wheel_of_fortune_prize_id,
+                        ) ??
+                        toOptionalNumber(normalizedWheelPrize?.wheel_of_fortune_prize_id) ??
+                        toOptionalNumber(normalizedWheelPrize?.prize_id) ??
+                        toOptionalNumber(prev.wheel_of_fortune_prize_id);
 
                     const nextSubtotal = preferCasco
                         ? data.sub_total_casco ?? data.sub_total ?? prev.sub_total
@@ -1221,7 +1370,12 @@ const BookingForm: React.FC<BookingFormProps> = ({
                                 : prev.total_before_wheel_prize,
                         applied_offers: nextAppliedOffers,
                         offers_discount: normalizedOffersDiscount,
+                        offer_fixed_discount: normalizedOfferFixedDiscount,
                         deposit_waived: normalizedDepositWaived,
+                        wheel_of_fortune_prize_id:
+                            typeof normalizedWheelPrizeId === "number"
+                                ? normalizedWheelPrizeId
+                                : prev.wheel_of_fortune_prize_id ?? null,
                     };
                 });
             } catch (error) {
@@ -1254,6 +1408,7 @@ const BookingForm: React.FC<BookingFormProps> = ({
         bookingInfo?.wheel_prize_discount,
         bookingInfo?.applied_offers,
         bookingInfo?.offers_discount,
+        bookingInfo?.offer_fixed_discount,
         bookingInfo?.deposit_waived,
         bookingInfo?.total_before_wheel_prize,
     ]);
@@ -1605,39 +1760,47 @@ const BookingForm: React.FC<BookingFormProps> = ({
                 return;
             }
             if (!value) {
-                updateBookingInfo((prev) => ({
-                    ...prev,
-                    wheel_prize: null,
-                    wheel_prize_discount: 0,
-                }));
-                return;
-            }
-            const option = wheelPrizeOptions.find((entry) => entry.value === value);
-            if (!option) {
-                return;
-            }
-            const discountNumeric =
-                toOptionalNumber(option.summary.discount_value) ??
-                toOptionalNumber(option.summary.amount) ??
-                0;
-            const summary: ReservationWheelPrizeSummary = {
-                ...option.summary,
-                discount_value: discountNumeric,
-            };
-            updateBookingInfo((prev) => {
-                const previousTotalBefore = toOptionalNumber(prev.total_before_wheel_prize);
-                const nextTotalBefore =
-                    previousTotalBefore ??
+            updateBookingInfo((prev) => ({
+                ...prev,
+                wheel_prize: null,
+                wheel_prize_discount: 0,
+                total_before_wheel_prize: null,
+                wheel_of_fortune_prize_id: null,
+            }));
+            return;
+        }
+        const option = wheelPrizeOptions.find((entry) => entry.value === value);
+        if (!option) {
+            return;
+        }
+        const discountNumeric =
+            toOptionalNumber(option.summary.discount_value) ??
+            toOptionalNumber(option.summary.amount) ??
+            0;
+        const summary: ReservationWheelPrizeSummary = {
+            ...option.summary,
+            discount_value: discountNumeric,
+            discount_value_deposit:
+                toOptionalNumber(option.summary.discount_value_deposit) ?? discountNumeric,
+            discount_value_casco:
+                toOptionalNumber(option.summary.discount_value_casco) ?? discountNumeric,
+        };
+        updateBookingInfo((prev) => {
+            const previousTotalBefore = toOptionalNumber(prev.total_before_wheel_prize);
+            const nextTotalBefore =
+                previousTotalBefore ??
                     (typeof prev.total === "number"
                         ? prev.total + discountNumeric
                         : null);
-                return {
-                    ...prev,
-                    wheel_prize: summary,
-                    wheel_prize_discount: discountNumeric,
-                    total_before_wheel_prize: nextTotalBefore,
-                };
-            });
+            return {
+                ...prev,
+                wheel_prize: summary,
+                wheel_prize_discount: discountNumeric,
+                total_before_wheel_prize: nextTotalBefore,
+                wheel_of_fortune_prize_id:
+                    summary.wheel_of_fortune_prize_id ?? summary.prize_id ?? prev.wheel_of_fortune_prize_id ?? null,
+            };
+        });
         },
         [hasBookingInfo, updateBookingInfo, wheelPrizeOptions],
     );
@@ -1651,6 +1814,8 @@ const BookingForm: React.FC<BookingFormProps> = ({
                 updateBookingInfo((prev) => ({
                     ...prev,
                     applied_offers: [],
+                    offers_discount: 0,
+                    offer_fixed_discount: 0,
                 }));
                 return;
             }
@@ -1668,6 +1833,8 @@ const BookingForm: React.FC<BookingFormProps> = ({
             updateBookingInfo((prev) => ({
                 ...prev,
                 applied_offers: [sanitizedOffer],
+                offers_discount: 0,
+                offer_fixed_discount: 0,
             }));
         },
         [hasBookingInfo, offerSelectOptions, updateBookingInfo],
@@ -1736,6 +1903,18 @@ const BookingForm: React.FC<BookingFormProps> = ({
         ? quote?.sub_total ?? quote?.sub_total_casco ?? null
         : quote?.sub_total_casco ?? quote?.sub_total ?? null;
     const discount = quote?.discount ?? 0;
+    const wheelPrizeDiscountValue =
+        typeof quote?.wheel_prize_discount === "number"
+            ? quote.wheel_prize_discount
+            : toOptionalNumber(bookingInfo.wheel_prize_discount) ??
+              toOptionalNumber(bookingInfo.wheel_prize?.discount_value) ??
+              null;
+    const normalizedWheelPrizeDiscount =
+        typeof wheelPrizeDiscountValue === "number"
+            ? Math.round(wheelPrizeDiscountValue * 100) / 100
+            : null;
+    const hasWheelPrizeDiscount =
+        typeof normalizedWheelPrizeDiscount === "number" && normalizedWheelPrizeDiscount !== 0;
     const discountedTotalQuote = bookingInfo.with_deposit
         ? quote?.total ?? quote?.total_casco ?? null
         : quote?.total_casco ?? quote?.total ?? null;
@@ -1757,6 +1936,7 @@ const BookingForm: React.FC<BookingFormProps> = ({
     const totalLei = formatLeiAmount(totalDisplay);
     const restToPayLei = formatLeiAmount(restToPay);
     const discountLei = formatLeiAmount(discount);
+    const wheelPrizeDiscountLei = formatLeiAmount(normalizedWheelPrizeDiscount);
     const baseRateLei = formatLeiAmount(baseRate);
     const roundedDiscountedRate = Math.round(discountedRate);
     const roundedDiscountedRateLei = formatLeiAmount(roundedDiscountedRate);
@@ -2344,6 +2524,12 @@ const BookingForm: React.FC<BookingFormProps> = ({
                                         <span>{discountLei ?? "—"}</span>
                                     </div>
                                 )}
+                                {hasWheelPrizeDiscount && (
+                                    <div className="font-dm-sans text-sm flex justify-between border-b border-b-1 mb-1">
+                                        <span>Reducere roata norocului:</span>
+                                        <span>{wheelPrizeDiscountLei ?? "—"}</span>
+                                    </div>
+                                )}
                                 <div className="font-dm-sans text-sm flex justify-between border-b border-b-1 mb-1">
                                     <span>Total:</span>
                                     <span>{totalLei ?? "—"}</span>
@@ -2410,6 +2596,12 @@ const BookingForm: React.FC<BookingFormProps> = ({
                                     <div className="font-dm-sans text-sm flex justify-between border-b border-b-1 mb-1">
                                         <span>Discount:</span>
                                         <span>{discount}€</span>
+                                    </div>
+                                )}
+                                {hasWheelPrizeDiscount && (
+                                    <div className="font-dm-sans text-sm flex justify-between border-b border-b-1 mb-1">
+                                        <span>Reducere roata norocului:</span>
+                                        <span>{normalizedWheelPrizeDiscount}€</span>
                                     </div>
                                 )}
                                 {depositWaived && (

--- a/docs/admin-bookings-api.md
+++ b/docs/admin-bookings-api.md
@@ -33,12 +33,25 @@ This convenience endpoint combines booking creation with PDF contract generation
   "withDeposit": true,
   "coupon_code": "SPRING15",
   "coupon_amount": 15,
+  "offers_discount": 30,
+  "offer_fixed_discount": 10,
+  "applied_offers": [
+    {
+      "id": 12,
+      "title": "Weekend fără garanție",
+      "offer_type": "percentage_discount",
+      "offer_value": "20",
+      "discount_label": "-20% reducere"
+    }
+  ],
   "wheel_prize_discount": 20,
   "wheel_of_fortune_prize_id": 4,
   "wheel_prize": {
     "prize_id": 4,
     "wheel_of_fortune_id": 2,
-    "discount_value": 20
+    "discount_value": 20,
+    "discount_value_deposit": 20,
+    "discount_value_casco": 20
   },
   "cnp": "2850312123456",
   "license": "B-12-XYZ"
@@ -65,6 +78,8 @@ This convenience endpoint combines booking creation with PDF contract generation
     "coupon_amount": 15.0,
     "coupon_code": "SPRING15",
     "status": "pending",
+    "offers_discount": 30.0,
+    "offer_fixed_discount": 10.0,
     "wheel_of_fortune_prize_id": 4,
     "wheel_prize_discount": 20.0,
     "total_before_wheel_prize": 231.0,
@@ -76,8 +91,28 @@ This convenience endpoint combines booking creation with PDF contract generation
       "type_label": "Reducere fixă",
       "amount": 20,
       "description": "Voucher aplicat automat la rezervare.",
-      "discount_value": 20
-    }
+      "discount_value": 20,
+      "discount_value_deposit": 20,
+      "discount_value_casco": 20
+    },
+    "applied_offers": [
+      {
+        "id": 12,
+        "title": "Weekend fără garanție",
+        "offer_type": "percentage_discount",
+        "offer_value": "20",
+        "discount_label": "-20% reducere",
+        "percent_discount_deposit": 20,
+        "percent_discount_casco": 20,
+        "fixed_discount_deposit": 10,
+        "fixed_discount_casco": 10,
+        "fixed_discount_deposit_applied": 10,
+        "fixed_discount_casco_applied": 10,
+        "discount_amount_deposit": 20,
+        "discount_amount_casco": 20,
+        "discount_amount": 20
+      }
+    ]
   },
   "message": "Booking created",
   "contract_url": "https://api.dacars.test/storage/contracts/generated/4d5fbd48-0e0a-4207-8f0b-b0fa5d5e6c6d.pdf"
@@ -158,16 +193,28 @@ Full update endpoint that validates the payload with `UpdateBookingRequest`, rec
     "title": "Reducere 20 €",
     "type": "fixed_discount",
     "discount_value": 20,
+    "discount_value_deposit": 20,
+    "discount_value_casco": 20,
     "eligible": true
   },
   "offers_discount": 30,
+  "offer_fixed_discount": 10,
   "applied_offers": [
     {
       "id": 12,
       "title": "Weekend fără garanție",
       "offer_type": "percentage_discount",
       "offer_value": "20",
-      "discount_label": "-20% reducere"
+      "discount_label": "-20% reducere",
+      "percent_discount_deposit": 20,
+      "percent_discount_casco": 20,
+      "fixed_discount_deposit": 10,
+      "fixed_discount_casco": 10,
+      "fixed_discount_deposit_applied": 10,
+      "fixed_discount_casco_applied": 10,
+      "discount_amount_deposit": 20,
+      "discount_amount_casco": 20,
+      "discount_amount": 20
     }
   ],
   "status": "reserved"
@@ -193,12 +240,15 @@ Full update endpoint that validates the payload with `UpdateBookingRequest`, rec
     "wheel_prize_discount": 20.0,
     "total_before_wheel_prize": 231.0,
     "offers_discount": 30.0,
+    "offer_fixed_discount": 10.0,
     "wheel_prize": {
       "wheel_of_fortune_prize_id": 4,
       "wheel_of_fortune_id": 2,
       "title": "Reducere 20 €",
       "type": "fixed_discount",
       "discount_value": 20,
+      "discount_value_deposit": 20,
+      "discount_value_casco": 20,
       "eligible": true
     },
     "applied_offers": [
@@ -207,7 +257,16 @@ Full update endpoint that validates the payload with `UpdateBookingRequest`, rec
         "title": "Weekend fără garanție",
         "offer_type": "percentage_discount",
         "offer_value": "20",
-        "discount_label": "-20% reducere"
+        "discount_label": "-20% reducere",
+        "percent_discount_deposit": 20,
+        "percent_discount_casco": 20,
+        "fixed_discount_deposit": 10,
+        "fixed_discount_casco": 10,
+        "fixed_discount_deposit_applied": 10,
+        "fixed_discount_casco_applied": 10,
+        "discount_amount_deposit": 20,
+        "discount_amount_casco": 20,
+        "discount_amount": 20
       }
     ]
   },
@@ -217,7 +276,7 @@ Full update endpoint that validates the payload with `UpdateBookingRequest`, rec
 
 Availability conflicts or invalid ranges result in HTTP 422 with details such as `"car_id": "Car not available in the selected interval."`.
 
-`wheel_prize`, `wheel_of_fortune_prize_id` și `wheel_prize_discount` trebuie trimise împreună atunci când operatorul selectează un premiu din roata norocului pentru perioada aleasă. Pentru oferte, payload-ul acceptă `applied_offers` (lista ofertelor aplicate în admin) și suma totală `offers_discount`; backend-ul sincronizează aceste valori cu promoțiile active și setează `deposit_waived` dacă oferta elimină garanția.
+`wheel_prize`, `wheel_of_fortune_prize_id` și `wheel_prize_discount` trebuie trimise împreună atunci când operatorul selectează un premiu din roata norocului pentru perioada aleasă, iar resursa returnată expune și `discount_value_deposit` / `discount_value_casco` pentru a evidenția impactul în funcție de plan. Pentru oferte, payload-ul acceptă `applied_offers` (lista ofertelor aplicate în admin), suma totală `offers_discount` și componenta fixă `offer_fixed_discount`; backend-ul sincronizează aceste valori cu promoțiile active și setează `deposit_waived` dacă oferta elimină garanția.
 
 ---
 

--- a/docs/bookings-api.md
+++ b/docs/bookings-api.md
@@ -58,6 +58,8 @@ Returns a Laravel paginator plus nested resources defined in `BookingResource`.
       "coupon_code": "SPRING15",
       "coupon_type": "percent",
       "tax_amount": 0.0,
+      "offers_discount": 30.0,
+      "offer_fixed_discount": 10.0,
       "wheel_of_fortune_prize_id": 4,
       "total_before_wheel_prize": 231.0,
       "wheel_prize_discount": 20.0,
@@ -75,8 +77,28 @@ Returns a Laravel paginator plus nested resources defined in `BookingResource`.
         "amount": 20,
         "description": "Voucher aplicat automat la rezervare.",
         "discount_value": 20,
+        "discount_value_deposit": 20,
+        "discount_value_casco": 20,
         "eligible": true
       },
+      "applied_offers": [
+        {
+          "id": 12,
+          "title": "Weekend fără garanție",
+          "offer_type": "percentage_discount",
+          "offer_value": "20",
+          "discount_label": "-20% reducere",
+          "percent_discount_deposit": 20,
+          "percent_discount_casco": 20,
+          "fixed_discount_deposit": 10,
+          "fixed_discount_casco": 10,
+          "fixed_discount_deposit_applied": 10,
+          "fixed_discount_casco_applied": 10,
+          "discount_amount_deposit": 20,
+          "discount_amount_casco": 20,
+          "discount_amount": 20
+        }
+      ],
       "services": [
         { "id": 1, "name": "Scaun copil" },
         { "id": 3, "name": "Asigurare CASCO extinsă" }
@@ -161,12 +183,25 @@ Validates the provided payload, resolves the base price via `CarPriceService`, a
   "coupon_code": "SPRING15",
   "service_ids": [1, 3],
   "total_services": 12,
+  "offers_discount": 30,
+  "offer_fixed_discount": 10,
+  "applied_offers": [
+    {
+      "id": 12,
+      "title": "Weekend fără garanție",
+      "offer_type": "percentage_discount",
+      "offer_value": "20",
+      "discount_label": "-20% reducere"
+    }
+  ],
   "wheel_prize_discount": 20,
   "wheel_of_fortune_prize_id": 4,
   "wheel_prize": {
     "prize_id": 4,
     "wheel_of_fortune_id": 2,
     "discount_value": 20,
+    "discount_value_deposit": 20,
+    "discount_value_casco": 20,
     "eligible": true
   }
 }
@@ -189,6 +224,7 @@ Validates the provided payload, resolves the base price via `CarPriceService`, a
   "total_casco": 302,
   "total_before_wheel_prize": 231,
   "offers_discount": 0,
+  "offer_fixed_discount": 0,
   "wheel_prize_discount": 20,
   "deposit_waived": false,
   "applied_offers": [],
@@ -201,6 +237,8 @@ Validates the provided payload, resolves the base price via `CarPriceService`, a
     "amount": 20,
     "description": "Voucher aplicat automat la rezervare.",
     "discount_value": 20,
+    "discount_value_deposit": 20,
+    "discount_value_casco": 20,
     "eligible": true
   }
 }
@@ -208,7 +246,7 @@ Validates the provided payload, resolves the base price via `CarPriceService`, a
 
 Validation failures respond with HTTP 422 detailing the offending fields (e.g. missing `car_id`, invalid `service_ids.*`).
 
-`offers_discount` raportează totalul valorilor scăzute de engine-ul de oferte, iar `applied_offers` conține lista promoțiilor validate (inclusiv titlul tradus și tipul din backend). Dacă o ofertă de tip `deposit_waiver` este acceptată, câmpul `deposit_waived` devine `true` pentru a semnala că rezervarea nu mai necesită garanție, deși tariful promoțional rămâne cel de depozit.
+`offers_discount` raportează totalul valorilor scăzute de engine-ul de oferte, `offer_fixed_discount` păstrează componenta fixă aferentă promoțiilor, iar `applied_offers` conține lista promoțiilor validate (inclusiv titlul tradus și tipul din backend). Dacă o ofertă de tip `deposit_waiver` este acceptată, câmpul `deposit_waived` devine `true` pentru a semnala că rezervarea nu mai necesită garanție, deși tariful promoțional rămâne cel de depozit.
 
 ---
 
@@ -248,6 +286,7 @@ Persists a booking using `BookingService::create`. The controller recomputes pri
   "coupon_code": "SPRING15",
   "coupon_type": "percent",
   "offers_discount": 30,
+  "offer_fixed_discount": 10,
   "deposit_waived": false,
   "applied_offers": [
     {
@@ -255,7 +294,16 @@ Persists a booking using `BookingService::create`. The controller recomputes pri
       "title": "Weekend fără garanție",
       "offer_type": "percentage_discount",
       "offer_value": "20",
-      "discount_label": "-20% reducere"
+      "discount_label": "-20% reducere",
+      "percent_discount_deposit": 20,
+      "percent_discount_casco": 20,
+      "fixed_discount_deposit": 10,
+      "fixed_discount_casco": 10,
+      "fixed_discount_deposit_applied": 10,
+      "fixed_discount_casco_applied": 10,
+      "discount_amount_deposit": 20,
+      "discount_amount_casco": 20,
+      "discount_amount": 20
     }
   ],
   "total_services": 12,
@@ -266,6 +314,8 @@ Persists a booking using `BookingService::create`. The controller recomputes pri
     "prize_id": 4,
     "wheel_of_fortune_id": 2,
     "discount_value": 20,
+    "discount_value_deposit": 20,
+    "discount_value_casco": 20,
     "eligible": true
   },
   "note": "Predare la terminal Plecări"
@@ -301,6 +351,7 @@ Persists a booking using `BookingService::create`. The controller recomputes pri
     "coupon_code": "SPRING15",
     "coupon_type": "percent",
     "offers_discount": 30.0,
+    "offer_fixed_discount": 10.0,
     "deposit_waived": false,
     "applied_offers": [
       {
@@ -308,7 +359,16 @@ Persists a booking using `BookingService::create`. The controller recomputes pri
         "title": "Weekend fără garanție",
         "offer_type": "percentage_discount",
         "offer_value": "20",
-        "discount_label": "-20% reducere"
+        "discount_label": "-20% reducere",
+        "percent_discount_deposit": 20,
+        "percent_discount_casco": 20,
+        "fixed_discount_deposit": 10,
+        "fixed_discount_casco": 10,
+        "fixed_discount_deposit_applied": 10,
+        "fixed_discount_casco_applied": 10,
+        "discount_amount_deposit": 20,
+        "discount_amount_casco": 20,
+        "discount_amount": 20
       }
     ],
     "tax_amount": 0.0,
@@ -329,6 +389,8 @@ Persists a booking using `BookingService::create`. The controller recomputes pri
       "amount": 20,
       "description": "Voucher aplicat automat la rezervare.",
       "discount_value": 20,
+      "discount_value_deposit": 20,
+      "discount_value_casco": 20,
       "eligible": true
     }
   },
@@ -338,7 +400,7 @@ Persists a booking using `BookingService::create`. The controller recomputes pri
 
 Availability conflicts or invalid date ranges trigger `422` errors sourced from `BookingService`.
 
-Pe lângă câmpurile existente, `BookingResource` serializată de endpoint include suma totală `offers_discount`, lista normalizată `applied_offers` și indicatorul `deposit_waived`, astfel încât aplicațiile client să știe ce promoții au fost acceptate și dacă garanția a fost eliminată în urma unei oferte.
+Pe lângă câmpurile existente, `BookingResource` serializată de endpoint include suma totală `offers_discount`, componenta fixă `offer_fixed_discount`, lista normalizată `applied_offers` și indicatorul `deposit_waived`, astfel încât aplicațiile client să știe ce promoții au fost acceptate și dacă garanția a fost eliminată în urma unei oferte. Structura `wheel_prize` reflectă și valorile `discount_value_deposit` / `discount_value_casco` pentru a evidenția impactul premiului în funcție de plan.
 
 ---
 

--- a/types/admin.ts
+++ b/types/admin.ts
@@ -338,7 +338,9 @@ export interface AdminBookingFormValues {
   total_before_wheel_prize: number | null;
   wheel_prize_discount: number;
   wheel_prize: ReservationWheelPrizeSummary | null;
+  wheel_of_fortune_prize_id?: number | string | null;
   offers_discount: number;
+  offer_fixed_discount: number;
   deposit_waived: boolean;
   applied_offers: ReservationAppliedOffer[];
   discount_applied?: number | null;
@@ -386,7 +388,9 @@ export const createEmptyBookingForm = (): AdminBookingFormValues => ({
   total_before_wheel_prize: null,
   wheel_prize_discount: 0,
   wheel_prize: null,
+  wheel_of_fortune_prize_id: null,
   offers_discount: 0,
+  offer_fixed_discount: 0,
   deposit_waived: false,
   applied_offers: [],
   discount_applied: null,

--- a/types/reservation.ts
+++ b/types/reservation.ts
@@ -76,6 +76,8 @@ export interface ReservationWheelPrizeSummary {
   expires_at?: string | null;
   eligible?: boolean | null;
   discount_value: number;
+  discount_value_deposit?: number | null;
+  discount_value_casco?: number | null;
 }
 
 export interface ReservationWheelPrizePayload {
@@ -84,6 +86,8 @@ export interface ReservationWheelPrizePayload {
   wheel_of_fortune_prize_id?: number | string | null;
   discount_value: number | string;
   eligible?: boolean | null;
+  discount_value_deposit?: number | string | null;
+  discount_value_casco?: number | string | null;
   [key: string]: unknown;
 }
 
@@ -93,6 +97,15 @@ export interface ReservationAppliedOffer {
   offer_type?: OfferKind | null;
   offer_value?: string | null;
   discount_label?: string | null;
+  percent_discount_deposit?: number | null;
+  percent_discount_casco?: number | null;
+  fixed_discount_deposit?: number | null;
+  fixed_discount_casco?: number | null;
+  fixed_discount_deposit_applied?: number | null;
+  fixed_discount_casco_applied?: number | null;
+  discount_amount_deposit?: number | null;
+  discount_amount_casco?: number | null;
+  discount_amount?: number | null;
 }
 
 export interface ReservationPayload extends ReservationFormData {
@@ -115,6 +128,7 @@ export interface ReservationPayload extends ReservationFormData {
   wheel_prize?: ReservationWheelPrizeSummary | ReservationWheelPrizePayload | null;
   applied_offers?: ReservationAppliedOffer[];
   note?: string;
+  offer_fixed_discount?: number;
 }
 
 export interface DiscountValidationPayload {
@@ -164,6 +178,7 @@ export interface QuotePricePayload {
   wheel_prize?: ReservationWheelPrizePayload | null;
   total_before_wheel_prize?: number | string;
   offers_discount?: number | string;
+  offer_fixed_discount?: number | string;
   deposit_waived?: boolean;
   applied_offers?: ReservationAppliedOffer[];
   [key: string]: unknown;
@@ -185,6 +200,7 @@ export interface QuotePriceResponse {
   coupon_code?: string | null;
   coupon_type?: string | null;
   offers_discount?: number;
+  offer_fixed_discount?: number;
   deposit_waived?: boolean;
   total_services?: number;
   service_ids?: number[];


### PR DESCRIPTION
## Summary
- normalise wheel of fortune data in the admin booking form so existing prizes stay selected and transmit deposit/casco values
- preserve offer selections with the new fixed discount metadata when quoting or updating bookings
- refresh booking API documentation to include the updated wheel prize and offer payload examples

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc2e12bd6c832993641f40b4b07c08