### PR TITLE
Fix reservation id handling in BookingContractForm

### DIFF
--- a/components/admin/BookingContractForm.tsx
+++ b/components/admin/BookingContractForm.tsx
@@ -123,10 +123,17 @@ const BookingContractForm: React.FC<BookingContractFormProps> = ({ open, onClose
   const revokeRef = useRef<(() => void) | undefined>();
 
   useEffect(() => {
-    const bookingNumber = reservation?.id ?? reservation?.bookingNumber ?? "";
+    const reservationId = reservation?.id ? String(reservation.id) : "";
+    const rawBookingNumber = reservation?.bookingNumber;
+    const bookingNumber =
+      rawBookingNumber != null && String(rawBookingNumber).trim().length > 0
+        ? String(rawBookingNumber)
+        : reservationId;
+
     const nextForm: BookingContractFormState = {
       ...EMPTY_FORM,
-      bookingNumber: bookingNumber ? String(bookingNumber) : "",
+      id: reservationId,
+      bookingNumber,
     };
 
     if (reservation) {


### PR DESCRIPTION
## Summary
- ensure the booking contract form stores the reservation id separately from the booking number
- fall back to the reservation id only when a booking number is not provided

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc53bf22e083299d71d43707e5a88b