### PR TITLE
Fix locale hydration to eliminate footer layout shift

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -55,8 +55,9 @@ export const metadata: Metadata = {
   },
 };
 
-const resolveInitialLocale = (): Locale => {
-  const localeCookie = cookies().get(LOCALE_STORAGE_KEY)?.value;
+const resolveInitialLocale = async (): Promise<Locale> => {
+  const cookieStore = await cookies();
+  const localeCookie = cookieStore.get(LOCALE_STORAGE_KEY)?.value;
   if (localeCookie && isLocale(localeCookie)) {
     return localeCookie;
   }
@@ -64,8 +65,8 @@ const resolveInitialLocale = (): Locale => {
   return DEFAULT_LOCALE;
 };
 
-export default function RootLayout({ children }: { children: ReactNode }) {
-  const initialLocale = resolveInitialLocale();
+export default async function RootLayout({ children }: { children: ReactNode }) {
+  const initialLocale = await resolveInitialLocale();
   const cookieKeyPattern = LOCALE_STORAGE_KEY.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
 
   return (


### PR DESCRIPTION
## Summary
- read the persisted locale from a cookie on the server so the initial HTML matches the hydrated language
- sync the locale across cookies, localStorage and DOM attributes before hydration to avoid footer shifts

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68dc5a68ca108329b9685ac2aec901b8