### PR TITLE
Optimize locale resolution caching

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { cache } from "react";
 import HomePageClient from "@/components/home/HomePageClient";
 import StructuredData from "@/components/StructuredData";
 import { SITE_NAME, SITE_URL } from "@/lib/config";
@@ -55,11 +56,11 @@ const HOME_SEO_COPY: Record<Locale, HomeSeoCopy> = {
 const FALLBACK_LOCALE: Locale = DEFAULT_LOCALE;
 const HREFLANG_LOCALES = ["ro", "en", "it", "es", "fr", "de"] as const;
 
-const resolveHomeSeo = async () => {
+const resolveHomeSeo = cache(async () => {
     const locale = await resolveRequestLocale();
     const copy = HOME_SEO_COPY[locale] ?? HOME_SEO_COPY[FALLBACK_LOCALE];
     return { locale, copy };
-};
+});
 
 export async function generateMetadata(): Promise<Metadata> {
     const { locale, copy } = await resolveHomeSeo();

--- a/lib/i18n/server.ts
+++ b/lib/i18n/server.ts
@@ -1,4 +1,5 @@
 import { cookies, headers } from "next/headers";
+import { cache } from "react";
 import { AVAILABLE_LOCALES, DEFAULT_LOCALE, type Locale } from "@/lib/i18n/config";
 import { isLocale } from "@/lib/i18n/utils";
 
@@ -69,7 +70,7 @@ const parseAcceptLanguage = (headerValue: string | null): Locale | null => {
     return null;
 };
 
-export const resolveRequestLocale = async (): Promise<Locale> => {
+const resolveRequestLocaleUncached = async (): Promise<Locale> => {
     const cookieStore = await cookies();
     for (const key of LOCALE_COOKIE_KEYS) {
         const value = cookieStore.get(key)?.value;
@@ -91,6 +92,8 @@ export const resolveRequestLocale = async (): Promise<Locale> => {
 
     return AVAILABLE_LOCALES[0];
 };
+
+export const resolveRequestLocale = cache(resolveRequestLocaleUncached);
 
 export const isSupportedLocale = (value: string): value is Locale => {
     return normalizeLocaleCandidate(value) != null;


### PR DESCRIPTION
## Summary
- cache server-side locale resolution so repeated calls in the same request reuse computed values
- memoize the home page SEO resolution to avoid duplicated locale lookups between metadata and rendering

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68dcee12d0808329a373c44d106b1ff8