### PR TITLE
Optimize docs routes for static rendering

### DIFF
--- a/app/docs/[slug]/page.tsx
+++ b/app/docs/[slug]/page.tsx
@@ -17,6 +17,7 @@ type DocPageProps = {
     }>;
 };
 
+export const dynamic = "force-static";
 export const dynamicParams = false;
 
 export function generateStaticParams() {

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -7,6 +7,8 @@ import { buildMetadata } from "@/lib/seo/meta";
 import { siteMetadata } from "@/lib/seo/siteMetadata";
 import { DOCS_HREFLANG_LOCALES, resolveDocsSeo } from "@/app/docs/seo";
 
+export const dynamic = "force-static";
+
 export async function generateMetadata(): Promise<Metadata> {
     const { locale, copy } = await resolveDocsSeo();
 

--- a/app/docs/seo.ts
+++ b/app/docs/seo.ts
@@ -1,5 +1,4 @@
 import { DEFAULT_LOCALE, type Locale } from "@/lib/i18n/config";
-import { resolveRequestLocale } from "@/lib/i18n/server";
 
 export type DocsSeoCopy = {
     pageTitle: string;
@@ -103,7 +102,7 @@ export const getDocsSeoCopy = (locale: Locale): DocsSeoCopy => {
 };
 
 export const resolveDocsSeo = async () => {
-    const locale = await resolveRequestLocale();
+    const locale = FALLBACK_LOCALE;
     const copy = getDocsSeoCopy(locale);
     return { locale, copy };
 };


### PR DESCRIPTION
## Summary
- mark the documentation index and article routes as static to avoid per-request rendering overhead
- simplify docs SEO resolution to use the preconfigured fallback locale without runtime detection

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68dcf041846883298859d14141ea0bd6