### PR TITLE
Optimize homepage interactions and loading

### DIFF
--- a/components/ElfsightWidget.tsx
+++ b/components/ElfsightWidget.tsx
@@ -1,36 +1,64 @@
-'use client'
+"use client";
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef } from "react";
+
+const SCRIPT_SRC = "https://static.elfsight.com/platform/platform.js";
+
+const appendElfsightScript = () => {
+    if (document.querySelector(`script[src="${SCRIPT_SRC}"]`)) {
+        return;
+    }
+
+    const script = document.createElement("script");
+    script.src = SCRIPT_SRC;
+    script.defer = true;
+    script.setAttribute("data-use-service-core", "");
+    document.body.appendChild(script);
+};
 
 export default function ElfsightWidget() {
-    const ref = useRef<HTMLElement>(null)
+    const sectionRef = useRef<HTMLElement>(null);
 
     useEffect(() => {
-        const current = ref.current
-        if (!current) return
+        const current = sectionRef.current;
+        if (!current) {
+            return;
+        }
 
-        const observer = new IntersectionObserver((entries) => {
-            if (entries[0].isIntersecting) {
-                const script = document.createElement('script')
-                script.src = 'https://static.elfsight.com/platform/platform.js'
-                script.defer = true
-                script.setAttribute('data-use-service-core', '')
-                document.body.appendChild(script)
-                observer.disconnect()
+        let observer: IntersectionObserver | null = null;
+
+        const handleIntersection: IntersectionObserverCallback = (entries) => {
+            const [entry] = entries;
+            if (!entry?.isIntersecting) {
+                return;
             }
-        })
 
-        observer.observe(current)
-        return () => observer.disconnect()
-    }, [])
+            appendElfsightScript();
+            current.dataset.widgetLoaded = "true";
+            observer?.disconnect();
+        };
+
+        if ("IntersectionObserver" in window) {
+            observer = new IntersectionObserver(handleIntersection, {
+                rootMargin: "200px 0px",
+            });
+            observer.observe(current);
+        } else {
+            appendElfsightScript();
+        }
+
+        return () => {
+            observer?.disconnect();
+        };
+    }, []);
 
     return (
-        <section ref={ref} className="py-20 bg-gray-50">
+        <section ref={sectionRef} className="py-20 bg-gray-50">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div className="text-center mb-16 animate-fade-in">
                     <div className="elfsight-app-59eeded2-1ad4-43a9-aba0-3cb2f0adac4c" />
                 </div>
             </div>
         </section>
-    )
+    );
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2119,42 +2119,47 @@ export class ApiClient {
         });
     }
 
-    async getWheelOfFortunePeriods(params: {
-        page?: number;
-        per_page?: number;
-        limit?: number;
-        active?: number | boolean;
-        is_active?: number | boolean;
-        with?: string | readonly string[];
-        include?: string | readonly string[];
-    } = {}): Promise<ApiListResult<WheelOfFortunePeriod>> {
+    async getWheelOfFortunePeriods(
+        params: {
+            page?: number;
+            per_page?: number;
+            limit?: number;
+            active?: number | boolean;
+            is_active?: number | boolean;
+            with?: string | readonly string[];
+            include?: string | readonly string[];
+            signal?: AbortSignal;
+        } = {},
+    ): Promise<ApiListResult<WheelOfFortunePeriod>> {
+        const { signal, ...queryParams } = params;
         const searchParams = new URLSearchParams();
-        if (params.page) searchParams.append('page', params.page.toString());
-        if (params.per_page) searchParams.append('per_page', params.per_page.toString());
-        if (params.limit) searchParams.append('limit', params.limit.toString());
+        if (queryParams.page) searchParams.append('page', queryParams.page.toString());
+        if (queryParams.per_page) searchParams.append('per_page', queryParams.per_page.toString());
+        if (queryParams.limit) searchParams.append('limit', queryParams.limit.toString());
         const appendBooleanParam = (key: string, value: number | boolean) => {
             const normalized = typeof value === 'boolean'
                 ? value ? '1' : '0'
                 : value.toString();
             searchParams.append(key, normalized);
         };
-        if (typeof params.active !== 'undefined') {
-            appendBooleanParam('active', params.active);
+        if (typeof queryParams.active !== 'undefined') {
+            appendBooleanParam('active', queryParams.active);
         }
-        if (typeof params.is_active !== 'undefined') {
-            appendBooleanParam('is_active', params.is_active);
+        if (typeof queryParams.is_active !== 'undefined') {
+            appendBooleanParam('is_active', queryParams.is_active);
         }
-        const withValue = resolveIncludeParam(params.with);
+        const withValue = resolveIncludeParam(queryParams.with);
         if (withValue) {
             searchParams.append('with', withValue);
         }
-        const includeValue = resolveIncludeParam(params.include);
+        const includeValue = resolveIncludeParam(queryParams.include);
         if (includeValue) {
             searchParams.append('include', includeValue);
         }
         const query = searchParams.toString();
         return this.request<ApiListResult<WheelOfFortunePeriod>>(
             `/wheel-of-fortune-periods${query ? `?${query}` : ''}`,
+            signal ? { signal } : undefined,
         );
     }
 


### PR DESCRIPTION
## Summary
- gate the wheel of fortune fetch logic behind booking selections and add abort handling to avoid redundant requests
- improve homepage popup visibility rules so the widget only appears when needed and resets cleanly
- lazy-load the Elfsight script once and with intersection observer guards to reduce render cost; expose abort support in the API client

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68dcf48b69e88329a6f3852278bcc99d