### PR TITLE
Add ApiClient tests for admin blog workflows

### DIFF
--- a/lib/__tests__/apiActivities.test.ts
+++ b/lib/__tests__/apiActivities.test.ts
@@ -1,0 +1,512 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from '@/lib/api';
+import type { ApiDeleteResponse, ApiItemResult, ApiListResult } from '@/types/api';
+import type {
+  ActivityMarkPaidResponse,
+  ActivityRecord,
+  ActivityWeeklySummary,
+  ActivityWeeklySummaryDispatchResponse,
+} from '@/types/activity-tracking';
+
+describe('ApiClient admin operational activities', () => {
+  const baseURL = 'https://admin-api.dacars.test';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('lists activities with sanitized filters and admin headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const params = {
+      week: ' 2024-W21 ',
+      from: ' 2024-05-20 ',
+      to: '   ',
+      car_id: 42,
+      type: ' cleaning ',
+      created_by: 9,
+      is_paid: true,
+      page: 2,
+      per_page: 25,
+    } as const;
+
+    const apiResponse: ApiListResult<ActivityRecord> = {
+      data: [
+        {
+          id: 1,
+          car_id: 42,
+          car_plate: 'B-101-XYZ',
+          performed_at: '2024-05-21T08:00:00Z',
+          type: 'cleaning',
+          amount: 150,
+          notes: null,
+          is_paid: true,
+          paid_at: '2024-05-22T10:00:00Z',
+          paid_by: 12,
+          paid_by_name: 'Ana',
+          created_by: 3,
+          created_by_name: 'Vlad',
+          created_at: '2024-05-21T08:05:00Z',
+          updated_at: '2024-05-21T08:05:00Z',
+        } as ActivityRecord,
+      ],
+      meta: {
+        current_page: 2,
+        per_page: 25,
+        total: 1,
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getActivities(params);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/activities?week=2024-W21&from=2024-05-20&car_id=42&type=cleaning&created_by=9&is_paid=true&page=2&per_page=25`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('retrieves a single activity with admin authentication headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiItemResult<ActivityRecord> = {
+      data: {
+        id: 7,
+        car_id: 55,
+        car_plate: 'CJ-22-ABC',
+        performed_at: '2024-05-18T09:00:00Z',
+        type: 'delivery',
+        amount: 220,
+        notes: 'Livrare aeroport',
+        is_paid: false,
+        paid_at: null,
+        paid_by: null,
+        paid_by_name: null,
+        created_by: 4,
+        created_by_name: 'Maria',
+        created_at: '2024-05-18T09:05:00Z',
+        updated_at: '2024-05-18T09:05:00Z',
+      } as ActivityRecord,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getActivity(7);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/activities/7`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('creates an activity removing undefined fields before sending the payload', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      car_id: 10,
+      performed_at: '2024-05-19T10:00:00Z',
+      type: 'cleaning' as const,
+      notes: null,
+      extra: undefined,
+    };
+
+    const apiResponse: ApiItemResult<ActivityRecord> = {
+      data: {
+        id: 11,
+        car_id: 10,
+        car_plate: 'TM-08-DCR',
+        performed_at: '2024-05-19T10:00:00Z',
+        type: 'cleaning',
+        amount: 180,
+        notes: null,
+        is_paid: false,
+        paid_at: null,
+        paid_by: null,
+        paid_by_name: null,
+        created_by: 2,
+        created_by_name: 'George',
+        created_at: '2024-05-19T10:05:00Z',
+        updated_at: '2024-05-19T10:05:00Z',
+      } as ActivityRecord,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createActivity(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/activities`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          car_id: 10,
+          performed_at: '2024-05-19T10:00:00Z',
+          type: 'cleaning',
+          notes: null,
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates an activity keeping only provided fields in the payload', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      performed_at: '2024-05-20T11:00:00Z',
+      notes: 'Curățare interior',
+      ignored: undefined,
+    };
+
+    const apiResponse: ApiItemResult<ActivityRecord> = {
+      data: {
+        id: 11,
+        car_id: 10,
+        car_plate: 'TM-08-DCR',
+        performed_at: '2024-05-20T11:00:00Z',
+        type: 'cleaning',
+        amount: 180,
+        notes: 'Curățare interior',
+        is_paid: false,
+        paid_at: null,
+        paid_by: null,
+        paid_by_name: null,
+        created_by: 2,
+        created_by_name: 'George',
+        created_at: '2024-05-19T10:05:00Z',
+        updated_at: '2024-05-20T11:05:00Z',
+      } as ActivityRecord,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateActivity(11, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/activities/11`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          performed_at: '2024-05-20T11:00:00Z',
+          notes: 'Curățare interior',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('deletes an activity while preserving admin authentication headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiDeleteResponse = { success: true };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.deleteActivity(15);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/activities/15`,
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('retrieves weekly summaries using sanitized query parameters', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const params = {
+      week: ' 2024-W22 ',
+      car_id: 33,
+    } as const;
+
+    const apiResponse: ApiItemResult<ActivityWeeklySummary> = {
+      data: {
+        week: '2024-W22',
+        start_date: '2024-05-27',
+        end_date: '2024-06-02',
+        activities_count: 5,
+        amount_per_activity: 120,
+        total_amount: 600,
+        breakdown_by_type: {
+          cleaning: { count: 3, amount: 300 },
+          delivery: { count: 2, amount: 300 },
+        },
+        breakdown_by_day: [
+          { date: '2024-05-27', count: 2, amount: 240 },
+          { date: '2024-05-28', count: 3, amount: 360 },
+        ],
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getActivityWeeklySummary(params);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/activities/weekly-summary?week=2024-W22&car_id=33`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse.data);
+  });
+
+  it('returns null when the weekly summary response has no data', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiItemResult<ActivityWeeklySummary> = { data: null };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getActivityWeeklySummary({ week: '2024-W23' });
+
+    expect(result).toBeNull();
+  });
+
+  it('dispatches the weekly summary removing undefined fields and returning the payload', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      week: '2024-W24',
+      channel: 'email' as const,
+      recipients: ['ops@dacars.ro'],
+      include_breakdown: undefined,
+    };
+
+    const apiResponse: ApiItemResult<ActivityWeeklySummaryDispatchResponse> = {
+      data: {
+        week: '2024-W24',
+        channel: 'email',
+        recipients: ['ops@dacars.ro'],
+        queued_job_id: 'job-123',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.dispatchActivityWeeklySummary(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/activities/weekly-summary/dispatch`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          week: '2024-W24',
+          channel: 'email',
+          recipients: ['ops@dacars.ro'],
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse.data);
+  });
+
+  it('throws when the weekly summary dispatch response lacks a payload', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      week: '2024-W24',
+      channel: 'email' as const,
+    };
+
+    const apiResponse: ApiItemResult<ActivityWeeklySummaryDispatchResponse> = {
+      data: null,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(client.dispatchActivityWeeklySummary(payload)).rejects.toThrow(
+      'Răspuns invalid pentru dispatch-ul sumarului săptămânal.',
+    );
+  });
+
+  it('marks activities as paid sanitizing payloads and returning the confirmation', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      week: '2024-W25',
+      car_id: 18,
+      extra: undefined,
+    };
+
+    const apiResponse: ApiItemResult<ActivityMarkPaidResponse> = {
+      data: {
+        mode: 'week',
+        marked_count: 4,
+        paid_at: '2024-06-10T12:00:00Z',
+        range: {
+          start_date: '2024-06-17',
+          end_date: '2024-06-23',
+          week: '2024-W25',
+        },
+        car_id: 18,
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.markActivitiesPaid(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/activities/mark-paid`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          week: '2024-W25',
+          car_id: 18,
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse.data);
+  });
+
+  it('throws when marking activities paid returns no payload', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiItemResult<ActivityMarkPaidResponse> = {
+      data: null,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(
+      client.markActivitiesPaid({ week: '2024-W25' }),
+    ).rejects.toThrow('Răspuns invalid pentru marcarea activităților ca achitate.');
+  });
+});
+

--- a/lib/__tests__/apiBlog.test.ts
+++ b/lib/__tests__/apiBlog.test.ts
@@ -1,0 +1,696 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from '@/lib/api';
+import type { ApiDeleteResponse, ApiItemResult, ApiListResult } from '@/types/api';
+import type {
+  BlogCategory,
+  BlogCategoryPayload,
+  BlogPost,
+  BlogPostPayload,
+  BlogTag,
+  BlogTagPayload,
+} from '@/types/blog';
+
+describe('ApiClient admin blog management', () => {
+  const baseURL = 'https://admin-api.dacars.test';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('lists blog categories with sanitized filters and pagination', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiListResult<BlogCategory> = {
+      data: [
+        {
+          id: 5,
+          name: 'Mașini electrice',
+          slug: 'masini-electrice',
+        },
+      ],
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getBlogCategories({
+      page: 2,
+      perPage: 20,
+      limit: 50,
+      name: '   ',
+      search: '  electrice  ',
+      slug: '  eco  ',
+      sort: '  -created_at ',
+      fields: ' id,name ',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/blog-categories?page=2&per_page=20&limit=50&name=electrice&slug=eco&sort=-created_at&fields=id%2Cname`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('creates a blog category with sanitized payload', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      name: 'Informații utile',
+      description: 'Sfaturi pentru închirieri',
+      status: 'active',
+      order: 3,
+      icon: undefined,
+    } satisfies BlogCategoryPayload;
+
+    const apiResponse: ApiItemResult<BlogCategory> = {
+      data: {
+        id: 12,
+        name: 'Informații utile',
+        description: 'Sfaturi pentru închirieri',
+        status: 'active',
+        order: 3,
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createBlogCategory(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/blog-categories`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'Informații utile',
+          description: 'Sfaturi pentru închirieri',
+          status: 'active',
+          order: 3,
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates a blog category and preserves admin headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      description: 'Articole tehnice și tutoriale',
+      status: 'inactive',
+      order: undefined,
+    } satisfies BlogCategoryPayload;
+
+    const apiResponse: ApiItemResult<BlogCategory> = {
+      data: {
+        id: 8,
+        name: 'Tehnologie',
+        description: 'Articole tehnice și tutoriale',
+        status: 'inactive',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateBlogCategory(8, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/blog-categories/8`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          description: 'Articole tehnice și tutoriale',
+          status: 'inactive',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('deletes a blog category', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiDeleteResponse = {
+      message: 'Categorie ștearsă',
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.deleteBlogCategory(11);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/blog-categories/11`,
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('lists blog tags with normalized filters', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiListResult<BlogTag> = {
+      data: [
+        {
+          id: 3,
+          name: 'roadtrip',
+          slug: 'roadtrip',
+        },
+      ],
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getBlogTags({
+      page: 1,
+      per_page: 30,
+      limit: 100,
+      name: '   ',
+      search: ' roadtrip  ',
+      slug: '  roadtrip  ',
+      sort: ' name ',
+      fields: ' id,slug ',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/blog-tags?page=1&per_page=30&limit=100&name=roadtrip&slug=roadtrip&sort=name&fields=id%2Cslug`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('creates a blog tag stripping undefined fields', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      name: 'Tips',
+      description: undefined,
+    } satisfies BlogTagPayload;
+
+    const apiResponse: ApiItemResult<BlogTag> = {
+      data: {
+        id: 9,
+        name: 'Tips',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createBlogTag(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/blog-tags`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'Tips',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates a blog tag with sanitized payload', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      description: 'Sfaturi pentru drumuri lungi',
+      name: undefined,
+    } satisfies BlogTagPayload;
+
+    const apiResponse: ApiItemResult<BlogTag> = {
+      data: {
+        id: 6,
+        name: 'roadtrip',
+        description: 'Sfaturi pentru drumuri lungi',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateBlogTag(6, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/blog-tags/6`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          description: 'Sfaturi pentru drumuri lungi',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('deletes a blog tag', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiDeleteResponse = {
+      success: true,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.deleteBlogTag(4);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/blog-tags/4`,
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('lists blog posts with include parameters and filters', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiListResult<BlogPost> = {
+      data: [
+        {
+          id: 21,
+          title: 'Top destinații 2024',
+          slug: 'top-destinatii-2024',
+          status: 'published',
+        },
+      ],
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getBlogPosts({
+      page: 3,
+      perPage: 15,
+      limit: 45,
+      category_id: 12,
+      author_id: ' 9 ',
+      status: ' published ',
+      slug: '  top-destinatii-2024 ',
+      title: '   ',
+      search: '  road trips ',
+      sort: ' -published_at ',
+      fields: ' id,title ',
+      include: [' author', 'category ', '', 'tags', 'author'],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/blog-posts?page=3&per_page=15&limit=45&category_id=12&author_id=+9+&status=published&slug=top-destinatii-2024&title=road+trips&sort=-published_at&fields=id%2Ctitle&include=author%2Ccategory%2Ctags`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('retrieves a single blog post', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiItemResult<BlogPost> = {
+      data: {
+        id: 34,
+        title: 'Test drive electric',
+        slug: 'test-drive-electric',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getBlogPost(34);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/blog-posts/34`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('creates a blog post using JSON payload', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      title: 'Ghid complet leasing auto',
+      excerpt: 'Tot ce trebuie să știi înainte de a închiria',
+      content: '<p>Detalii utile pentru clienți.</p>',
+      status: 'draft',
+      category_id: 4,
+      author_id: 2,
+      tag_ids: [1, '2'],
+      image: undefined,
+    } satisfies BlogPostPayload;
+
+    const apiResponse: ApiItemResult<BlogPost> = {
+      data: {
+        id: 56,
+        title: 'Ghid complet leasing auto',
+        slug: 'ghid-complet-leasing-auto',
+        status: 'draft',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createBlogPost(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/blog-posts`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          title: 'Ghid complet leasing auto',
+          excerpt: 'Tot ce trebuie să știi înainte de a închiria',
+          content: '<p>Detalii utile pentru clienți.</p>',
+          status: 'draft',
+          category_id: 4,
+          author_id: 2,
+          tag_ids: [1, '2'],
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('creates a blog post using FormData', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const formData = new FormData();
+    formData.append('title', 'Promoții vara 2024');
+    formData.append('status', 'scheduled');
+
+    const apiResponse: ApiItemResult<BlogPost> = {
+      data: {
+        id: 61,
+        title: 'Promoții vara 2024',
+        slug: 'promotii-vara-2024',
+        status: 'scheduled',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createBlogPost(formData);
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/blog-posts`,
+      expect.objectContaining({
+        method: 'POST',
+        body: formData,
+        headers: expect.objectContaining({
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(requestInit?.headers).not.toHaveProperty('Content-Type');
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates a blog post using JSON payload', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      status: 'published',
+      published_at: '2024-04-01T10:00:00Z',
+      meta_description: 'Ghid complet pentru clienți',
+      image: undefined,
+    } satisfies BlogPostPayload;
+
+    const apiResponse: ApiItemResult<BlogPost> = {
+      data: {
+        id: 41,
+        title: 'Experiențe premium',
+        slug: 'experiente-premium',
+        status: 'published',
+        published_at: '2024-04-01T10:00:00Z',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateBlogPost(41, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/blog-posts/41`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          status: 'published',
+          published_at: '2024-04-01T10:00:00Z',
+          meta_description: 'Ghid complet pentru clienți',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates a blog post using FormData', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const formData = new FormData();
+    formData.append('status', 'archived');
+
+    const apiResponse: ApiItemResult<BlogPost> = {
+      data: {
+        id: 72,
+        title: 'Promoții trecute',
+        slug: 'promotii-trecute',
+        status: 'archived',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateBlogPost(72, formData);
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/blog-posts/72`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: formData,
+        headers: expect.objectContaining({
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(requestInit?.headers).not.toHaveProperty('Content-Type');
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('deletes a blog post', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiDeleteResponse = {
+      message: 'Articol eliminat',
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.deleteBlogPost(19);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/blog-posts/19`,
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+});

--- a/lib/__tests__/apiBookings.test.ts
+++ b/lib/__tests__/apiBookings.test.ts
@@ -1,0 +1,501 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from '@/lib/api';
+import type { ApiItemResult, UnknownRecord } from '@/types/api';
+
+describe('ApiClient bookings management', () => {
+  const baseURL = 'https://admin-api.dacars.test';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('creates a booking with the expected payload and headers', async () => {
+    const client = new ApiClient(baseURL);
+    const payload = {
+      car_id: 42,
+      customer_id: 7,
+      start_date: '2024-05-01',
+      end_date: '2024-05-05',
+      status: 'draft',
+    } satisfies Record<string, unknown>;
+    const apiResponse: ApiItemResult<UnknownRecord> = {
+      data: {
+        id: 101,
+        status: 'draft',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createBooking(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/bookings`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(payload),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates an existing booking using the admin token and JSON headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      status: 'confirmed',
+      total_price: 259.99,
+    } satisfies Record<string, unknown>;
+    const apiResponse: ApiItemResult<UnknownRecord> = {
+      data: {
+        id: 55,
+        status: 'confirmed',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateBooking(55, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/bookings/55`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify(payload),
+        cache: 'no-cache',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('propagates backend validation errors when booking updates fail', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'Date invalide pentru rezervare' }), {
+        status: 422,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(
+      client.updateBooking(13, { start_date: undefined }),
+    ).rejects.toThrow('Date invalide pentru rezervare');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/bookings/13`,
+      expect.objectContaining({
+        method: 'PUT',
+      }),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('checks car availability by POST-ing the payload as JSON', async () => {
+    const client = new ApiClient(baseURL);
+
+    const payload = {
+      car_id: 77,
+      start_date: '2024-06-10',
+      end_date: '2024-06-15',
+    };
+
+    const apiResponse = {
+      data: {
+        available: true,
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.checkCarAvailability(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/bookings/availability/check`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(payload),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('quotes a booking price keeping the payload untouched', async () => {
+    const client = new ApiClient(baseURL);
+
+    const payload = {
+      pickup_location: 'OTP',
+      dropoff_location: 'OTP',
+      rental_start_date: '2024-07-01',
+      rental_end_date: '2024-07-05',
+      car_category_id: 5,
+    };
+
+    const apiResponse = {
+      data: {
+        total: '999.00',
+        currency: 'EUR',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.quotePrice(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/bookings/quote`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(payload),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates booking dates using the admin authorization headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('super-admin');
+
+    const payload = {
+      arrivalDate: '2024-08-01',
+      arrivalTime: '10:00',
+      returnDate: '2024-08-05',
+      returnTime: '14:00',
+    };
+
+    const apiResponse = {
+      data: {
+        id: 301,
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateBookingDate(301, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/bookings/301/update-date`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify(payload),
+        cache: 'no-cache',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          Authorization: 'Bearer super-admin',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('retrieves booking info without include parameters when none are provided', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse = {
+      data: { id: 501 },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getBookingInfo(501);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${baseURL}/bookings/501`);
+    expect(options).toEqual(expect.objectContaining({
+      headers: expect.objectContaining({
+        Authorization: 'Bearer admin-token',
+      }),
+    }));
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('retrieves booking info with sanitized include parameters', async () => {
+    const client = new ApiClient(baseURL);
+
+    const apiResponse = {
+      data: { id: 77 },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await client.getBookingInfo(77, {
+      include: ['customer ', '', ' car', 'customer'],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl, options] = fetchMock.mock.calls[0];
+    const parsed = new URL(calledUrl);
+    expect(parsed.pathname).toBe('/bookings/77');
+    expect(parsed.searchParams.get('include')).toBe('customer,car');
+    expect(options).toEqual(expect.objectContaining({
+      headers: expect.objectContaining({
+        'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+      }),
+    }));
+  });
+
+  it('lists bookings with normalized filters and pagination params', async () => {
+    const client = new ApiClient(baseURL);
+
+    const apiResponse = {
+      data: [],
+      meta: {
+        current_page: 1,
+        per_page: 25,
+        total: 0,
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await client.getBookings({
+      page: 2,
+      perPage: 25,
+      status: ' confirmed ',
+      search: '  TesLa ',
+      include: ['customer', 'car', 'customer'],
+      customer_id: 9,
+      car_id: 11,
+      start_date: '2024-09-01',
+      end_date: '',
+      from: '2024-08-01',
+      to: '2024-08-31',
+      limit: 50,
+    });
+
+    const [calledUrl] = fetchMock.mock.calls[0];
+    const parsed = new URL(calledUrl);
+
+    expect(parsed.pathname).toBe('/bookings');
+    expect(parsed.searchParams.get('include')).toBe('customer,car');
+    expect(parsed.searchParams.get('page')).toBe('2');
+    expect(parsed.searchParams.get('per_page')).toBe('25');
+    expect(parsed.searchParams.get('limit')).toBe('50');
+    expect(parsed.searchParams.get('status')).toBe('confirmed');
+    expect(parsed.searchParams.get('search')).toBe('TesLa');
+    expect(parsed.searchParams.get('customer_id')).toBe('9');
+    expect(parsed.searchParams.get('car_id')).toBe('11');
+    expect(parsed.searchParams.get('start_date')).toBe('2024-09-01');
+    expect(parsed.searchParams.get('from')).toBe('2024-08-01');
+    expect(parsed.searchParams.get('to')).toBe('2024-08-31');
+    expect(parsed.searchParams.has('end_date')).toBe(false);
+  });
+
+  it('generates a booking contract as PDF with admin credentials', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('contract-admin');
+
+    const payload = {
+      booking_id: 912,
+      with_signature: true,
+    };
+
+    const apiResponse = {
+      data: { url: 'https://storage/contract.pdf' },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.generateContract(payload, 912);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/bookings/contract/912`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(payload),
+        cache: 'no-cache',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Accept: 'application/pdf',
+          Authorization: 'Bearer contract-admin',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('stores and generates a new booking contract in a single call', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('contract-admin');
+
+    const payload = {
+      booking_id: 913,
+      with_signature: false,
+    };
+
+    const apiResponse = {
+      data: { url: 'https://storage/contract-913.pdf' },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.storeAndGenerateContract(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/bookings/store-contract`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(payload),
+        cache: 'no-cache',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Accept: 'application/pdf',
+          Authorization: 'Bearer contract-admin',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('lists customers with optional search filters for rentals', async () => {
+    const client = new ApiClient(baseURL);
+
+    const apiResponse = {
+      data: [],
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await client.getCustomers({ search: '   Popescu   ', limit: 5 });
+
+    const [calledUrl] = fetchMock.mock.calls[0];
+    const parsed = new URL(calledUrl);
+
+    expect(parsed.pathname).toBe('/customers');
+    expect(parsed.searchParams.get('search')).toBe('   Popescu   ');
+    expect(parsed.searchParams.get('limit')).toBe('5');
+  });
+
+  it('searches customers by phone when attaching them to bookings', async () => {
+    const client = new ApiClient(baseURL);
+
+    const apiResponse = {
+      data: [{ id: 1, phone: '+40700000000' }],
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.searchCustomersByPhone('+40700000000');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/customers/get/byphone`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ phone: '+40700000000' }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+});

--- a/lib/__tests__/apiCarAttributes.test.ts
+++ b/lib/__tests__/apiCarAttributes.test.ts
@@ -1,0 +1,504 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from '@/lib/api';
+import type { ApiItemResult, LookupRecord } from '@/types/api';
+
+describe('ApiClient admin car attribute management', () => {
+  const baseURL = 'https://admin-api.dacars.test';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('creates a car make with sanitized payload and admin headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      name: 'Dacia',
+      slug: 'dacia',
+      status: 'published',
+      country: undefined,
+    } as const;
+
+    const apiResponse: ApiItemResult<LookupRecord> = {
+      data: {
+        id: 11,
+        name: 'Dacia',
+        slug: 'dacia',
+        status: 'published',
+      } satisfies LookupRecord,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createCarMake(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/car-makes`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'Dacia',
+          slug: 'dacia',
+          status: 'published',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates a car make keeping only provided fields', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      name: 'Dacia Spring',
+      status: undefined,
+      slug: 'dacia-spring',
+    } as const;
+
+    const apiResponse: ApiItemResult<LookupRecord> = {
+      data: {
+        id: 11,
+        name: 'Dacia Spring',
+        slug: 'dacia-spring',
+      } satisfies LookupRecord,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateCarMake(11, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/car-makes/11`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          name: 'Dacia Spring',
+          slug: 'dacia-spring',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('creates a car type with sanitized payload and admin headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      name: 'SUV',
+      slug: 'suv',
+      status: 'draft',
+      description: undefined,
+    } as const;
+
+    const apiResponse: ApiItemResult<LookupRecord> = {
+      data: {
+        id: 22,
+        name: 'SUV',
+        slug: 'suv',
+        status: 'draft',
+      } satisfies LookupRecord,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createCarType(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/car-types`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'SUV',
+          slug: 'suv',
+          status: 'draft',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates a car type keeping only provided fields', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      name: 'SUV compact',
+      status: 'published',
+      slug: undefined,
+    } as const;
+
+    const apiResponse: ApiItemResult<LookupRecord> = {
+      data: {
+        id: 22,
+        name: 'SUV compact',
+        status: 'published',
+      } satisfies LookupRecord,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateCarType(22, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/car-types/22`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          name: 'SUV compact',
+          status: 'published',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('creates a car transmission with sanitized payload and admin headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      name: 'Automată',
+      slug: 'automata',
+      status: 'published',
+      gears: undefined,
+    } as const;
+
+    const apiResponse: ApiItemResult<LookupRecord> = {
+      data: {
+        id: 31,
+        name: 'Automată',
+        slug: 'automata',
+        status: 'published',
+      } satisfies LookupRecord,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createCarTransmission(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/car-transmissions`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'Automată',
+          slug: 'automata',
+          status: 'published',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates a car transmission keeping only provided fields', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      name: 'Automată secvențială',
+      status: 'draft',
+      slug: undefined,
+    } as const;
+
+    const apiResponse: ApiItemResult<LookupRecord> = {
+      data: {
+        id: 31,
+        name: 'Automată secvențială',
+        status: 'draft',
+      } satisfies LookupRecord,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateCarTransmission(31, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/car-transmissions/31`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          name: 'Automată secvențială',
+          status: 'draft',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('creates a car fuel with sanitized payload and admin headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      name: 'Electric',
+      slug: 'electric',
+      status: 'published',
+      description: undefined,
+    } as const;
+
+    const apiResponse: ApiItemResult<LookupRecord> = {
+      data: {
+        id: 44,
+        name: 'Electric',
+        slug: 'electric',
+        status: 'published',
+      } satisfies LookupRecord,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createCarFuel(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/car-fuels`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'Electric',
+          slug: 'electric',
+          status: 'published',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates a car fuel keeping only provided fields', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      name: 'Hibrid plug-in',
+      status: 'published',
+      slug: undefined,
+    } as const;
+
+    const apiResponse: ApiItemResult<LookupRecord> = {
+      data: {
+        id: 44,
+        name: 'Hibrid plug-in',
+        status: 'published',
+      } satisfies LookupRecord,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateCarFuel(44, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/car-fuels/44`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          name: 'Hibrid plug-in',
+          status: 'published',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('creates a car color with sanitized payload and admin headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      name: 'Albastru safir',
+      slug: 'albastru-safir',
+      status: 'draft',
+      hex: undefined,
+    } as const;
+
+    const apiResponse: ApiItemResult<LookupRecord> = {
+      data: {
+        id: 55,
+        name: 'Albastru safir',
+        slug: 'albastru-safir',
+        status: 'draft',
+      } satisfies LookupRecord,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createCarColor(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/car-colors`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'Albastru safir',
+          slug: 'albastru-safir',
+          status: 'draft',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates a car color keeping only provided fields', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      name: 'Albastru safir perlat',
+      status: 'published',
+      slug: undefined,
+    } as const;
+
+    const apiResponse: ApiItemResult<LookupRecord> = {
+      data: {
+        id: 55,
+        name: 'Albastru safir perlat',
+        status: 'published',
+      } satisfies LookupRecord,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateCarColor(55, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/car-colors/55`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          name: 'Albastru safir perlat',
+          status: 'published',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+});

--- a/lib/__tests__/apiCarCashflows.test.ts
+++ b/lib/__tests__/apiCarCashflows.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from '@/lib/api';
+import type { ApiItemResult } from '@/types/api';
+import type { CarCashflowRecord } from '@/types/car-cashflow';
+
+describe('ApiClient admin car cashflows management', () => {
+  const baseURL = 'https://admin-api.dacars.test';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('creates a car cashflow sanitizing payload and applying admin headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      car_id: 42,
+      direction: 'income',
+      payment_method: 'card',
+      total_amount: 1250,
+      occurred_on: '2024-04-15',
+      category: 'Încasări rezervări',
+      description: 'Plată integrală pentru rezervarea DAC-2024-0415',
+      cash_amount: undefined,
+      card_amount: 1250,
+      created_by: 7,
+    } as const;
+
+    const apiResponse: ApiItemResult<CarCashflowRecord> = {
+      data: {
+        id: 301,
+        car_id: 42,
+        direction: 'income',
+        payment_method: 'card',
+        total_amount: 1250,
+        occurred_on: '2024-04-15',
+      } as CarCashflowRecord,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createCarCashflow(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/car-cashflows`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          car_id: 42,
+          direction: 'income',
+          payment_method: 'card',
+          total_amount: 1250,
+          occurred_on: '2024-04-15',
+          category: 'Încasări rezervări',
+          description: 'Plată integrală pentru rezervarea DAC-2024-0415',
+          card_amount: 1250,
+          created_by: 7,
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates a car cashflow keeping provided fields and admin authentication', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      category: 'Costuri service',
+      description: 'Schimb plăcuțe frână și verificare suspensie',
+      payment_method: 'cash_card',
+      total_amount: 860,
+      cash_amount: 200,
+      card_amount: 660,
+      occurred_on: '2024-05-02',
+      created_by: undefined,
+    } as const;
+
+    const apiResponse: ApiItemResult<CarCashflowRecord> = {
+      data: {
+        id: 88,
+        car_id: 12,
+        direction: 'expense',
+        payment_method: 'cash_card',
+        total_amount: 860,
+        occurred_on: '2024-05-02',
+      } as CarCashflowRecord,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateCarCashflow(88, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/car-cashflows/88`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          category: 'Costuri service',
+          description: 'Schimb plăcuțe frână și verificare suspensie',
+          payment_method: 'cash_card',
+          total_amount: 860,
+          cash_amount: 200,
+          card_amount: 660,
+          occurred_on: '2024-05-02',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+});

--- a/lib/__tests__/apiCars.test.ts
+++ b/lib/__tests__/apiCars.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from '@/lib/api';
+import type { ApiItemResult, ApiListResult, UnknownRecord } from '@/types/api';
+import type { ApiCar } from '@/types/car';
+
+describe('ApiClient cars management', () => {
+  const baseURL = 'https://admin-api.dacars.test';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('creates a car with sanitized JSON payload and admin headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      name: 'Audi Q5',
+      seats: 5,
+      status: 'draft',
+      vin: undefined,
+    } satisfies Record<string, unknown>;
+
+    const apiResponse: ApiItemResult<UnknownRecord> = {
+      data: {
+        id: 77,
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createCar(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/cars`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'Audi Q5',
+          seats: 5,
+          status: 'draft',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('sends FormData without overriding the content type when creating a car', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const formData = new FormData();
+    formData.append('name', 'BMW X3');
+    formData.append('status', 'draft');
+
+    const apiResponse: ApiItemResult<UnknownRecord> = {
+      data: {
+        id: 202,
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createCar(formData);
+
+    const [, options] = fetchMock.mock.calls.at(-1) ?? [];
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/cars`,
+      expect.objectContaining({
+        method: 'POST',
+        body: formData,
+        headers: expect.objectContaining({
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    const headers = (options?.headers ?? {}) as Record<string, string>;
+    expect(headers).not.toHaveProperty('Content-Type');
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates a car with sanitized payload and authorization token', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      status: 'active',
+      price_per_day: 89.9,
+      description: 'SUV de familie',
+      image: undefined,
+    } satisfies Record<string, unknown>;
+
+    const apiResponse: ApiItemResult<UnknownRecord> = {
+      data: {
+        id: 55,
+        status: 'active',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateCar(55, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/cars/55`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          status: 'active',
+          price_per_day: 89.9,
+          description: 'SUV de familie',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('filters cars using the provided listing query parameters', async () => {
+    const client = new ApiClient(baseURL);
+
+    const apiResponse: ApiListResult<ApiCar> = {
+      data: [
+        {
+          id: 1,
+          name: 'Tesla Model 3',
+        } as ApiCar,
+      ],
+      meta: {
+        current_page: 2,
+        per_page: 10,
+        total: 32,
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getCars({
+      search: 'Tesla',
+      page: 2,
+      perPage: 10,
+      language: 'en',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/cars/en?search=Tesla&page=2&perPage=10`,
+      expect.objectContaining({
+        credentials: 'omit',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('maps UI filters when searching cars by availability window', async () => {
+    const client = new ApiClient(baseURL);
+
+    const apiResponse: ApiListResult<ApiCar> = {
+      data: [
+        {
+          id: 9,
+          name: 'BMW X5',
+        } as ApiCar,
+      ],
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getCarsByDateCriteria({
+      start_date: '2024-07-01',
+      end_date: '2024-07-05',
+      make_id: 7,
+      limit: 12,
+      search: 'BMW',
+    });
+
+    const [url, options] = fetchMock.mock.calls.at(-1) ?? [];
+
+    expect(typeof url).toBe('string');
+    expect(url).toContain('/cars/ro?');
+
+    const query = (url as string).split('?')[1];
+    const params = new URLSearchParams(query);
+
+    expect(params.get('start_date')).toBe('2024-07-01');
+    expect(params.get('end_date')).toBe('2024-07-05');
+    expect(params.get('make_id')).toBe('7');
+    expect(params.get('limit')).toBe('12');
+    expect(params.get('name_like')).toBe('BMW');
+    expect(params.get('include')).toBe('make,type,transmission,fuel,categories,colors');
+
+    expect(options).toEqual(
+      expect.objectContaining({
+        credentials: 'omit',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+});

--- a/lib/__tests__/apiCategories.test.ts
+++ b/lib/__tests__/apiCategories.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from '@/lib/api';
+import type { ApiItemResult } from '@/types/api';
+import type { CarCategory } from '@/types/car';
+
+describe('ApiClient admin categories management', () => {
+  const baseURL = 'https://admin-api.dacars.test';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('creates a category using sanitized payload and admin headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload: { name: string; description?: string } = {
+      name: 'SUV Premium',
+      description: undefined,
+    };
+
+    const apiResponse: ApiItemResult<CarCategory> = {
+      data: {
+        id: 12,
+        name: 'SUV Premium',
+      } as CarCategory,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createCategory(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/car-categories`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'SUV Premium',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates a category keeping only provided fields and propagating auth headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload: { name: string; description?: string } = {
+      name: 'SUV Business',
+      description: 'Flotă business pentru parteneri',
+    };
+
+    const apiResponse: ApiItemResult<CarCategory> = {
+      data: {
+        id: 44,
+        name: 'SUV Business',
+        description: 'Flotă business pentru parteneri',
+      } as CarCategory,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateCategory(44, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/car-categories/44`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          name: 'SUV Business',
+          description: 'Flotă business pentru parteneri',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+});

--- a/lib/__tests__/apiDynamicPrices.test.ts
+++ b/lib/__tests__/apiDynamicPrices.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from '@/lib/api';
+import type { ApiItemResult } from '@/types/api';
+import type { DynamicPrice } from '@/types/admin';
+
+describe('ApiClient admin dynamic prices management', () => {
+  const baseURL = 'https://admin-api.dacars.test';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('creates a dynamic price with the expected payload and admin headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      start_from: '2024-07-01',
+      end_to: '2024-07-31',
+      enabled: true,
+      percentages: [
+        {
+          percentage_start: 1,
+          percentage_end: 3,
+          percentage_amount: 5,
+        },
+        {
+          percentage_start: 4,
+          percentage_end: 7,
+          percentage_amount: 12,
+        },
+      ],
+    } satisfies Parameters<ApiClient['createDynamicPrice']>[0];
+
+    const apiResponse: ApiItemResult<DynamicPrice> = {
+      data: {
+        id: 9,
+        start_from: '2024-07-01',
+        end_to: '2024-07-31',
+        enabled: true,
+        percentages: payload.percentages,
+      } as DynamicPrice,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createDynamicPrice(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/dynamic-prices`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(payload),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates a dynamic price keeping provided percentages and propagating auth headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      start_from: '2024-08-01',
+      end_to: '2024-08-31',
+      enabled: false,
+      percentages: [
+        {
+          id: 1,
+          dynamic_price_id: 3,
+          percentage_start: 1,
+          percentage_end: 5,
+          percentage_amount: 8,
+        },
+        {
+          percentage_start: 6,
+          percentage_end: 10,
+          percentage_amount: 15,
+        },
+      ],
+    } satisfies Parameters<ApiClient['updateDynamicPrice']>[1];
+
+    const apiResponse: ApiItemResult<DynamicPrice> = {
+      data: {
+        id: 3,
+        start_from: '2024-08-01',
+        end_to: '2024-08-31',
+        enabled: false,
+        percentages: payload.percentages,
+      } as DynamicPrice,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateDynamicPrice(3, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/dynamic-prices/3`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify(payload),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+});

--- a/lib/__tests__/apiExpenses.test.ts
+++ b/lib/__tests__/apiExpenses.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from '@/lib/api';
+import type { ApiDeleteResponse, ApiItemResult, ApiListResult } from '@/types/api';
+import type { Expense } from '@/types/expense';
+
+describe('ApiClient admin expenses management', () => {
+  const baseURL = 'https://admin-api.dacars.test';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('creates a fleet expense sanitizing payload and adding admin headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      type: 'service',
+      description: 'Revizie completă pentru Dacia Jogger',
+      amount: 1850.5,
+      spent_at: '2024-06-12',
+      car_id: 17,
+      is_recurring: false,
+      ends_on: undefined,
+    } as const;
+
+    const apiResponse: ApiItemResult<Expense> = {
+      data: {
+        id: 520,
+        type: 'service',
+        amount: 1850.5,
+        spent_at: '2024-06-12',
+      } as Expense,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createExpense(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/expenses`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          type: 'service',
+          description: 'Revizie completă pentru Dacia Jogger',
+          amount: 1850.5,
+          spent_at: '2024-06-12',
+          car_id: 17,
+          is_recurring: false,
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('lists fleet expenses applying filters, includes, and admin authentication', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const params = {
+      page: 2,
+      perPage: 25,
+      per_page: 10,
+      limit: 50,
+      type: ' service ',
+      car_id: ' 42 ',
+      is_recurring: true,
+      include: ['car', ' created_by_user ', 'car'],
+    } as const;
+
+    const apiResponse: ApiListResult<Expense> = {
+      data: [],
+      meta: { current_page: 2, per_page: 25 },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getExpenses(params);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, config] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(url).toBe(
+      `${baseURL}/expenses?page=2&per_page=25&limit=50&type=service&car_id=42&is_recurring=1&include=car%2Ccreated_by_user`,
+    );
+    expect(config.credentials).toBe('omit');
+    expect(config.headers).toEqual(
+      expect.objectContaining({
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer admin-token',
+        'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('retrieves a fleet expense with trimmed include parameters and admin headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiItemResult<Expense> = {
+      data: {
+        id: 912,
+        type: 'parcare',
+        amount: 90,
+        spent_at: '2024-07-01',
+      } as Expense,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getExpense(912, {
+      include: [' car ', 'created_by_user', 'car'],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, config] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(url).toBe(`${baseURL}/expenses/912?include=car%2Ccreated_by_user`);
+    expect(config.credentials).toBe('omit');
+    expect(config.headers).toEqual(
+      expect.objectContaining({
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer admin-token',
+        'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates a fleet expense keeping provided fields with admin authentication', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      description: 'Revizie completă și înlocuire plăcuțe',
+      amount: 2120,
+      is_recurring: 0,
+      spent_at: '2024-06-20',
+    } as const;
+
+    const apiResponse: ApiItemResult<Expense> = {
+      data: {
+        id: 520,
+        type: 'service',
+        description: 'Revizie completă și înlocuire plăcuțe',
+        amount: 2120,
+        spent_at: '2024-06-20',
+      } as Expense,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateExpense(520, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/expenses/520`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          description: 'Revizie completă și înlocuire plăcuțe',
+          amount: 2120,
+          is_recurring: 0,
+          spent_at: '2024-06-20',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('deletes a fleet expense while preserving admin authentication headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiDeleteResponse = { message: 'Expense deleted successfully' };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.deleteExpense(520);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/expenses/520`,
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+});

--- a/lib/__tests__/apiMailBranding.test.ts
+++ b/lib/__tests__/apiMailBranding.test.ts
@@ -1,0 +1,499 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from '@/lib/api';
+import type {
+  MailBrandingResponse,
+  MailBrandingUpdatePayload,
+  MailTemplateAttachmentsResponse,
+  MailTemplateDetailResponse,
+  MailTemplateUpdatePayload,
+  MailTemplatesResponse,
+} from '@/types/mail';
+
+describe('ApiClient admin mail branding management', () => {
+  const baseURL = 'https://admin-api.dacars.test';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('fetches mail branding settings with authentication headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: MailBrandingResponse = {
+      data: {
+        site: {
+          title: 'DaCars',
+          url: 'https://dacars.ro',
+          logo_path: '/storage/logo.png',
+          logo_max_height: 48,
+          description: 'Închirieri auto premium',
+          email: 'contact@dacars.ro',
+          phone: '+40 745 000 000',
+          phone_link: '+40745000000',
+          support_phone: null,
+          support_phone_link: null,
+          address: 'Strada Viitorului 10',
+          availability: 'Non-stop',
+          menu_items: [],
+          footer_links: [],
+          social_links: [],
+        },
+        colors: {
+          berkeley: '#1b1f3b',
+          jade: '#3ba381',
+          jadeLight: '#bde7d0',
+          eefie: '#eef1f5',
+        },
+        resolved_site: {
+          title: 'DaCars',
+          url: 'https://dacars.ro',
+          logo_path: '/storage/logo.png',
+          menu_items: [],
+          footer_links: [],
+          social_links: [],
+        },
+        resolved_colors: {
+          berkeley: '#1b1f3b',
+          jade: '#3ba381',
+          jadeLight: '#bde7d0',
+          eefie: '#eef1f5',
+        },
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getMailBrandingSettings();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/mail-branding-settings`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates mail branding settings trimming undefined fields from payload', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload: MailBrandingUpdatePayload = {
+      site: {
+        title: 'DaCars.ro',
+        description: 'Rezervă-ți mașina de azi',
+        email: 'contact@dacars.ro',
+        logo_max_height: 64,
+        menu_items: [
+          { label: 'Flotă', url: 'https://dacars.ro/flota' },
+          { label: 'Contact', url: 'https://dacars.ro/contact' },
+        ],
+        footer_links: [
+          { label: 'Termeni și condiții', url: 'https://dacars.ro/termeni' },
+        ],
+        social_links: [{ label: 'Facebook', url: 'https://facebook.com/dacars' }],
+        phone: '+40 745 000 000',
+        phone_link: '+40745000000',
+        support_phone: undefined,
+        support_phone_link: undefined,
+      },
+      colors: {
+        berkeley: '#1b1f3b',
+        jade: '#3ba381',
+        jadeLight: '#bde7d0',
+        eefie: undefined,
+      },
+    };
+
+    const apiResponse: MailBrandingResponse = {
+      data: {
+        site: payload.site!,
+        colors: {
+          berkeley: '#1b1f3b',
+          jade: '#3ba381',
+          jadeLight: '#bde7d0',
+          eefie: '#eef1f5',
+        },
+        resolved_site: payload.site!,
+        resolved_colors: {
+          berkeley: '#1b1f3b',
+          jade: '#3ba381',
+          jadeLight: '#bde7d0',
+          eefie: '#eef1f5',
+        },
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateMailBrandingSettings(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/mail-branding-settings`,
+      expect.objectContaining({
+        method: 'PUT',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    const [, options] = fetchMock.mock.calls.at(-1) ?? [];
+    expect(options?.body).toBeDefined();
+    expect(JSON.parse(String(options?.body))).toEqual({
+      site: {
+        title: 'DaCars.ro',
+        description: 'Rezervă-ți mașina de azi',
+        email: 'contact@dacars.ro',
+        logo_max_height: 64,
+        menu_items: [
+          { label: 'Flotă', url: 'https://dacars.ro/flota' },
+          { label: 'Contact', url: 'https://dacars.ro/contact' },
+        ],
+        footer_links: [
+          { label: 'Termeni și condiții', url: 'https://dacars.ro/termeni' },
+        ],
+        social_links: [{ label: 'Facebook', url: 'https://facebook.com/dacars' }],
+        phone: '+40 745 000 000',
+        phone_link: '+40745000000',
+      },
+      colors: {
+        berkeley: '#1b1f3b',
+        jade: '#3ba381',
+        jadeLight: '#bde7d0',
+      },
+    });
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('lists mail templates using admin authentication', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: MailTemplatesResponse = {
+      data: [
+        {
+          key: 'booking-confirmation',
+          path: 'emails/booking-confirmation.blade.php',
+          name: 'Confirmare rezervare',
+          title: 'Rezervarea ta DaCars',
+          subject: 'Confirmarea rezervării',
+          updated_at: '2024-05-12T09:00:00Z',
+        },
+      ],
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getMailTemplates();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/mail-templates`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('retrieves a mail template detail trimming and encoding the key', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: MailTemplateDetailResponse = {
+      data: {
+        key: 'booking/confirmation',
+        path: 'emails/booking-confirmation.blade.php',
+        name: 'Confirmare rezervare',
+        title: 'Rezervarea ta DaCars',
+        subject: 'Confirmarea rezervării',
+        contents: '<p>Mulțumim pentru rezervare!</p>',
+        updated_at: '2024-05-12T09:00:00Z',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getMailTemplateDetail(' booking/confirmation ');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/mail-templates/booking%2Fconfirmation`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates a mail template using sanitized key and payload', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload: MailTemplateUpdatePayload = {
+      title: 'Rezervarea ta este confirmată',
+      subject: 'Confirmare rezervare DaCars',
+      contents: '<p>Rezervarea a fost procesată.</p>',
+    };
+
+    const apiResponse: MailTemplateDetailResponse = {
+      data: {
+        key: 'booking-confirmation',
+        path: 'emails/booking-confirmation.blade.php',
+        name: 'Confirmare rezervare',
+        title: payload.title!,
+        subject: payload.subject!,
+        contents: payload.contents!,
+        updated_at: '2024-05-12T09:05:00Z',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateMailTemplate(' booking-confirmation ', payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/mail-templates/booking-confirmation`,
+      expect.objectContaining({
+        method: 'PUT',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    const [, options] = fetchMock.mock.calls.at(-1) ?? [];
+    expect(JSON.parse(String(options?.body))).toEqual(payload);
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('uploads a mail template attachment with provided file name and deposit flag', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const file = new File(['contract'], 'contract.pdf', { type: 'application/pdf' });
+
+    const apiResponse: MailTemplateAttachmentsResponse = {
+      data: {
+        attachments: [
+          {
+            id: 'uuid-1',
+            name: 'Contract PDF',
+            filename: 'contract.pdf',
+            with_deposit: true,
+          },
+        ],
+        attachment: {
+          id: 'uuid-1',
+          name: 'Contract PDF',
+          filename: 'contract.pdf',
+          with_deposit: true,
+        },
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.uploadMailTemplateAttachment(' booking-confirmation ', file, {
+      withDeposit: true,
+    });
+
+    const [, options] = fetchMock.mock.calls.at(-1) ?? [];
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/mail-templates/booking-confirmation/attachments`,
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.any(FormData),
+        headers: expect.objectContaining({
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    const body = options?.body as FormData;
+    const appendedFile = body.get('file');
+    expect(appendedFile).toBeInstanceOf(File);
+    expect((appendedFile as File).name).toBe('contract.pdf');
+
+    const entries = Array.from(body.entries());
+    expect(entries).toContainEqual(['with_deposit', '1']);
+
+    const headers = (options?.headers ?? {}) as Record<string, string>;
+    expect(headers).not.toHaveProperty('Content-Type');
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('uploads a mail template attachment restricting to no-deposit bookings', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const file = new File(['contract'], 'no-deposit.pdf', { type: 'application/pdf' });
+
+    const apiResponse: MailTemplateAttachmentsResponse = {
+      data: {
+        attachments: [],
+        attachment: undefined,
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await client.uploadMailTemplateAttachment(' invoice ', file, { withDeposit: false });
+
+    const [, options] = fetchMock.mock.calls.at(-1) ?? [];
+    const entries = Array.from((options?.body as FormData).entries());
+    expect(entries).toContainEqual(['with_deposit', '0']);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/mail-templates/invoice/attachments`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+      }),
+    );
+  });
+
+  it('uploads a mail template attachment with default filename and no deposit flag', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const blob = new Blob(['terms'], { type: 'text/plain' });
+
+    const apiResponse: MailTemplateAttachmentsResponse = {
+      data: {
+        attachments: [],
+        attachment: undefined,
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await client.uploadMailTemplateAttachment(' terms ', blob);
+
+    const [, options] = fetchMock.mock.calls.at(-1) ?? [];
+    const body = options?.body as FormData;
+    const appendedFile = body.get('file');
+    expect(appendedFile).toBeInstanceOf(File);
+    expect((appendedFile as File).name).toBe('attachment');
+    const entries = Array.from(body.keys());
+    expect(entries).toEqual(['file']);
+  });
+
+  it('deletes a mail template attachment with sanitized identifiers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: MailTemplateAttachmentsResponse = {
+      data: {
+        attachments: [],
+        attachment: undefined,
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.deleteMailTemplateAttachment(
+      ' booking confirmation ',
+      ' uuid-1234 ',
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/mail-templates/booking%20confirmation/attachments/uuid-1234`,
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+});

--- a/lib/__tests__/apiOffers.test.ts
+++ b/lib/__tests__/apiOffers.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from '@/lib/api';
+import type { ApiItemResult } from '@/types/api';
+import type { Offer } from '@/types/offer';
+
+describe('ApiClient admin offers management', () => {
+  const baseURL = 'https://admin-api.dacars.test';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('creates an offer using sanitized payload and admin headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      title: 'Early Booking',
+      status: 'published',
+      badge: undefined,
+      offer_type: 'percentage_discount',
+      offer_value: '15%',
+      features: ['Ridicare gratuită de la aeroport'],
+      benefits: 'Asigurare completă inclusă',
+      starts_at: '2024-10-01T00:00:00Z',
+      ends_at: null,
+    } as const;
+
+    const apiResponse: ApiItemResult<Offer> = {
+      data: {
+        id: 12,
+        title: 'Early Booking',
+        status: 'published',
+        offer_type: 'percentage_discount',
+        offer_value: '15%',
+      } as Offer,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createOffer(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/offers`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          title: 'Early Booking',
+          status: 'published',
+          offer_type: 'percentage_discount',
+          offer_value: '15%',
+          features: ['Ridicare gratuită de la aeroport'],
+          benefits: 'Asigurare completă inclusă',
+          starts_at: '2024-10-01T00:00:00Z',
+          ends_at: null,
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates an offer keeping only provided fields and admin auth headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      status: 'draft',
+      description: 'Promoție early bird pentru rezervările făcute cu 30 de zile înainte.',
+      primary_cta_label: 'Rezervă acum',
+      primary_cta_url: 'https://dacars.test/oferte/early-booking',
+      background_class: 'bg-berkeley-600',
+      text_class: undefined,
+    } as const;
+
+    const apiResponse: ApiItemResult<Offer> = {
+      data: {
+        id: 12,
+        title: 'Early Booking',
+        status: 'draft',
+        description: 'Promoție early bird pentru rezervările făcute cu 30 de zile înainte.',
+      } as Offer,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateOffer(12, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/offers/12`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          status: 'draft',
+          description: 'Promoție early bird pentru rezervările făcute cu 30 de zile înainte.',
+          primary_cta_label: 'Rezervă acum',
+          primary_cta_url: 'https://dacars.test/oferte/early-booking',
+          background_class: 'bg-berkeley-600',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+});

--- a/lib/__tests__/apiRoles.test.ts
+++ b/lib/__tests__/apiRoles.test.ts
@@ -1,0 +1,375 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from '@/lib/api';
+import type { ApiDeleteResponse, ApiItemResult, ApiListResult } from '@/types/api';
+import type { Role, RolePermissionGroup } from '@/types/roles';
+
+describe('ApiClient admin role management', () => {
+  const baseURL = 'https://admin-api.dacars.test';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('lists roles with pagination and permission includes', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiListResult<Role> = {
+      data: [
+        {
+          id: 1,
+          slug: 'admin',
+          name: 'Administrator',
+          description: 'Acces complet',
+          is_default: true,
+          created_by: 10,
+          updated_by: 10,
+          created_at: '2024-01-01T08:00:00Z',
+          updated_at: '2024-03-01T09:30:00Z',
+          permissions: [
+            {
+              id: 101,
+              name: 'manage_users',
+              group: 'utilizatori',
+            },
+          ],
+        },
+      ],
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getRoles({
+      page: 2,
+      perPage: 25,
+      includePermissions: true,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/roles?page=2&per_page=25&include=permissions`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('lists roles without permission includes when not requested', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiListResult<Role> = {
+      data: [],
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getRoles();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/roles`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('retrieves a single role with permissions include when requested', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiItemResult<Role> = {
+      data: {
+        id: 7,
+        slug: 'fleet-manager',
+        name: 'Fleet Manager',
+        description: 'Gestionează flota',
+        is_default: false,
+        created_by: 3,
+        updated_by: 5,
+        created_at: '2024-02-01T10:00:00Z',
+        updated_at: '2024-03-10T10:00:00Z',
+        permissions: [
+          {
+            id: 205,
+            name: 'manage_cars',
+            group: 'flota',
+          },
+        ],
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getRole(7, { includePermissions: true });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/roles/7?include=permissions`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('retrieves a single role without includes when not provided', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiItemResult<Role> = {
+      data: {
+        id: 8,
+        slug: 'support',
+        name: 'Suport clienți',
+        description: null,
+        is_default: false,
+        permissions: [],
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getRole(8);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/roles/8`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('creates a new role with sanitized payload and admin headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiItemResult<Role> = {
+      data: {
+        id: 11,
+        slug: 'marketing',
+        name: 'Marketing',
+        description: 'Campanii și promoții',
+        is_default: false,
+        permissions: [],
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createRole({
+      slug: 'marketing',
+      name: 'Marketing',
+      description: undefined,
+      is_default: false,
+      permissions: ['manage_campaigns'],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/roles`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        body: JSON.stringify({
+          slug: 'marketing',
+          name: 'Marketing',
+          is_default: false,
+          permissions: ['manage_campaigns'],
+        }),
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates an existing role while stripping undefined fields', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiItemResult<Role> = {
+      data: {
+        id: 11,
+        slug: 'marketing',
+        name: 'Marketing & Sales',
+        description: 'Campanii și oferte',
+        is_default: false,
+        permissions: [
+          {
+            id: 307,
+            name: 'manage_campaigns',
+            group: 'marketing',
+          },
+        ],
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateRole(11, {
+      name: 'Marketing & Sales',
+      description: 'Campanii și oferte',
+      permissions: ['manage_campaigns', 'view_reports'],
+      is_default: undefined,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/roles/11`,
+      expect.objectContaining({
+        method: 'PUT',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        body: JSON.stringify({
+          name: 'Marketing & Sales',
+          description: 'Campanii și oferte',
+          permissions: ['manage_campaigns', 'view_reports'],
+        }),
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('deletes a role with admin authentication headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiDeleteResponse = {
+      success: true,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.deleteRole(9);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/roles/9`,
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('fetches grouped permissions for role assignment', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: RolePermissionGroup[] = [
+      {
+        group: 'flota',
+        permissions: [
+          {
+            id: 410,
+            name: 'manage_cars',
+            group: 'flota',
+          },
+        ],
+      },
+    ];
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getPermissionGroups();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/permissions/grouped`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+});

--- a/lib/__tests__/apiServiceReports.test.ts
+++ b/lib/__tests__/apiServiceReports.test.ts
@@ -1,0 +1,281 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from '@/lib/api';
+import type { ApiDeleteResponse, ApiItemResult, ApiListResult } from '@/types/api';
+import type { ServiceReport } from '@/types/service-report';
+
+describe('ApiClient admin service reports', () => {
+  const baseURL = 'https://admin-api.dacars.test';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('lists service reports applying sanitized query params and includes', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const params = {
+      page: 2,
+      perPage: 25,
+      limit: 10,
+      car_id: ' 42 ',
+      mechanic_name: '  Ion  ',
+      include: [' car ', ' mechanic ', 'car'],
+    } as const;
+
+    const apiResponse: ApiListResult<ServiceReport> = {
+      data: [
+        {
+          id: 9,
+          mechanic_name: 'Ion',
+          serviced_at: '2024-05-10',
+          car_id: 42,
+        } as ServiceReport,
+      ],
+      meta: {
+        current_page: 2,
+        per_page: 25,
+        total: 1,
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getServiceReports(params);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/service-reports?page=2&per_page=25&limit=10&car_id=42&mechanic_name=Ion&include=car%2Cmechanic`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('supports per_page fallback when perPage is missing', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiListResult<ServiceReport> = {
+      data: [],
+      meta: {
+        current_page: 1,
+        per_page: 15,
+        total: 0,
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getServiceReports({ per_page: 15, car_id: 55 });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/service-reports?per_page=15&car_id=55`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('retrieves a specific service report while resolving include filters', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiItemResult<ServiceReport> = {
+      data: {
+        id: 77,
+        mechanic_name: 'Maria',
+        serviced_at: '2024-06-01',
+      } as ServiceReport,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getServiceReport(77, { include: [' car ', 'car', ' mechanics '] });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/service-reports/77?include=car%2Cmechanics`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('creates a service report omitting undefined fields in the payload', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      mechanic_name: 'Ionuț',
+      serviced_at: '2024-07-15',
+      car_id: 9,
+      work_performed: 'Schimb ulei',
+      extra: undefined,
+    } as const;
+
+    const apiResponse: ApiItemResult<ServiceReport> = {
+      data: {
+        id: 12,
+        mechanic_name: 'Ionuț',
+        serviced_at: '2024-07-15',
+        car_id: 9,
+        work_performed: 'Schimb ulei',
+      } as ServiceReport,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createServiceReport(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/service-reports`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          mechanic_name: 'Ionuț',
+          serviced_at: '2024-07-15',
+          car_id: 9,
+          work_performed: 'Schimb ulei',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates a service report keeping only provided values', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      mechanic_name: 'Andrei',
+      work_performed: null,
+      observations: 'Verificat sistem de frânare',
+    } as const;
+
+    const apiResponse: ApiItemResult<ServiceReport> = {
+      data: {
+        id: 15,
+        mechanic_name: 'Andrei',
+        serviced_at: '2024-08-03',
+        observations: 'Verificat sistem de frânare',
+      } as ServiceReport,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateServiceReport(15, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/service-reports/15`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          mechanic_name: 'Andrei',
+          work_performed: null,
+          observations: 'Verificat sistem de frânare',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('deletes a service report with admin authentication headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiDeleteResponse = {
+      message: 'Raport de service șters',
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.deleteServiceReport(19);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/service-reports/19`,
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+});

--- a/lib/__tests__/apiServices.test.ts
+++ b/lib/__tests__/apiServices.test.ts
@@ -1,0 +1,474 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from '@/lib/api';
+import type { ApiDeleteResponse, ApiItemResult, ApiListResult } from '@/types/api';
+import type { Service, ServiceTranslation } from '@/types/reservation';
+
+describe('ApiClient admin services management', () => {
+  const baseURL = 'https://admin-api.dacars.test';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('lists services with filters, sanitized query params and language', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const params = {
+      language: 'ro',
+      page: 2,
+      perPage: 30,
+      limit: 10,
+      status: ' pending ',
+      name_like: ' Transfer VIP ',
+      include: ' translations ',
+    } as const;
+
+    const apiResponse: ApiListResult<Service> = {
+      data: [
+        {
+          id: 1,
+          name: 'Transfer VIP',
+          price: 99,
+          status: 'pending',
+        } as Service,
+      ],
+      meta: {
+        current_page: 2,
+        per_page: 30,
+        total: 1,
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getServices(params);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/services/ro?page=2&per_page=30&limit=10&status=pending&name_like=Transfer+VIP&include=translations`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('uses stored language and per_page fallback when listing services', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+    client.setLanguage('en');
+
+    const apiResponse: ApiListResult<Service> = {
+      data: [],
+      meta: {
+        current_page: 1,
+        per_page: 15,
+        total: 0,
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getServices({ per_page: 15 });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/services/en?per_page=15`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('retrieves a specific service including optional language', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiItemResult<Service> = {
+      data: {
+        id: 12,
+        name: 'Asigurare CASCO',
+        price: 15,
+      } as Service,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getService(12, 'de-DE');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/services/12/de-DE`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('retrieves a service using the stored admin language when not provided', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+    client.setLanguage('es');
+
+    const apiResponse: ApiItemResult<Service> = {
+      data: {
+        id: 4,
+        name: 'Conductor privado',
+      } as Service,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getService(4);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/services/4/es`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('creates a service using sanitized payload and admin headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      name: 'Șofer personal',
+      price: 49,
+      status: 'published',
+      description: undefined,
+      content: undefined,
+    } as const;
+
+    const apiResponse: ApiItemResult<Service> = {
+      data: {
+        id: 7,
+        name: 'Șofer personal',
+        price: 49,
+        status: 'published',
+      } as Service,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createService(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/services`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'Șofer personal',
+          price: 49,
+          status: 'published',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates an existing service keeping only provided fields', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      description: 'Serviciu cu șofer 24/7',
+      content: '<p>Transfer privat cu șofer dedicat.</p>',
+      price: '79',
+    } as const;
+
+    const apiResponse: ApiItemResult<Service> = {
+      data: {
+        id: 7,
+        name: 'Șofer personal',
+        description: 'Serviciu cu șofer 24/7',
+        content: '<p>Transfer privat cu șofer dedicat.</p>',
+        price: 79,
+      } as Service,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateService(7, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/services/7`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          description: 'Serviciu cu șofer 24/7',
+          content: '<p>Transfer privat cu șofer dedicat.</p>',
+          price: '79',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('deletes a service using the admin context', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiDeleteResponse = {
+      message: 'Serviciu șters',
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.deleteService(9);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/services/9`,
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('returns normalized translations list for a service', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse = {
+      data: [
+        {
+          lang_code: 'ro',
+          name: 'Transfer aeroport',
+        },
+        {
+          lang_code: 'en',
+          name: 'Airport transfer',
+        },
+      ],
+      meta: { total: 2 },
+    } satisfies ApiListResult<ServiceTranslation>;
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getServiceTranslations(4);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/services/4/translations`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse.data);
+  });
+
+  it('returns translations directly when API already sends an array', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ServiceTranslation[] = [
+      {
+        lang_code: 'ro',
+        name: 'Transfer aeroport',
+      },
+    ];
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getServiceTranslations(9);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/services/9/translations`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('upserts a translation stripping lang_code and undefined fields', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload: Partial<ServiceTranslation> = {
+      lang_code: 'fr',
+      name: 'Transfert aéroport',
+      description: undefined,
+      content: '<p>Navetă privată cu șofer.</p>',
+    };
+
+    const apiResponse: ServiceTranslation = {
+      lang_code: 'fr',
+      name: 'Transfert aéroport',
+      content: '<p>Navetă privată cu șofer.</p>',
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.upsertServiceTranslation(3, ' fr-FR ', payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/services/3/translations/fr-FR`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          name: 'Transfert aéroport',
+          content: '<p>Navetă privată cu șofer.</p>',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('deletes a specific translation keeping admin headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiDeleteResponse = {
+      message: 'Traducere eliminată',
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.deleteServiceTranslation(5, ' it-IT ');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/services/5/translations/it-IT`,
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+});

--- a/lib/__tests__/apiUsers.test.ts
+++ b/lib/__tests__/apiUsers.test.ts
@@ -1,0 +1,434 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from '@/lib/api';
+import type { ApiDeleteResponse, ApiItemResult, ApiListResult, ApiMessageResponse } from '@/types/api';
+import type { User } from '@/types/auth';
+
+
+describe('ApiClient admin user management', () => {
+  const baseURL = 'https://admin-api.dacars.test';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('lists users with filters, role includes, and sorting', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiListResult<User> = {
+      data: [
+        {
+          id: 1,
+          first_name: 'Ana',
+          last_name: 'Ionescu',
+          email: 'ana@dacars.ro',
+          username: 'ana.ionescu',
+          avatar: null,
+          super_user: true,
+          manage_supers: true,
+          roles: ['admin'],
+          permissions: ['manage_users'],
+          last_login: '2024-03-18T10:00:00Z',
+          created_at: '2024-01-05T08:00:00Z',
+          updated_at: '2024-03-18T10:00:00Z',
+        },
+      ],
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getUsers({
+      search: 'ana',
+      page: 2,
+      perPage: 15,
+      limit: 0,
+      roles: ['admin', 'manager'],
+      includeRoles: true,
+      sort: '-created_at',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/users?search=ana&page=2&per_page=15&limit=0&roles%5B%5D=admin&roles%5B%5D=manager&include=roles&sort=-created_at`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('lists users filtered by a single role without including relationships', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiListResult<User> = {
+      data: [],
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getUsers({
+      roles: 'support',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/users?roles=support`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('fetches a single user with optional role include', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiItemResult<User> = {
+      data: {
+        id: 7,
+        first_name: 'Matei',
+        last_name: 'Popescu',
+        email: 'matei@dacars.ro',
+        username: 'matei.popescu',
+        avatar: null,
+        super_user: false,
+        manage_supers: false,
+        roles: ['support'],
+        permissions: [],
+        last_login: null,
+        created_at: '2024-02-01T08:00:00Z',
+        updated_at: '2024-03-01T08:00:00Z',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getUser(7, { includeRoles: true });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/users/7?include=roles`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('fetches a single user without includes when not requested', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiItemResult<User> = {
+      data: {
+        id: 12,
+        first_name: 'Irina',
+        last_name: 'Stan',
+        email: 'irina@dacars.ro',
+        username: 'irina.stan',
+        avatar: null,
+        super_user: false,
+        manage_supers: false,
+        roles: [],
+        permissions: [],
+        last_login: null,
+        created_at: '2024-02-14T08:00:00Z',
+        updated_at: '2024-03-12T08:00:00Z',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.getUser(12);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/users/12`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('creates a user while stripping undefined fields from payload', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload: Parameters<ApiClient['createUser']>[0] = {
+      first_name: 'Cristina',
+      last_name: 'Marin',
+      email: 'cristina@dacars.ro',
+      username: 'cristina.marin',
+      password: 'SuperSecret123',
+      roles: ['admin', 'support'],
+      super_user: false,
+      manage_supers: true,
+      avatar: undefined,
+      extra_field: undefined,
+    };
+
+    const apiResponse: ApiItemResult<User> = {
+      data: {
+        id: 25,
+        first_name: 'Cristina',
+        last_name: 'Marin',
+        email: 'cristina@dacars.ro',
+        username: 'cristina.marin',
+        avatar: null,
+        super_user: false,
+        manage_supers: true,
+        roles: ['admin', 'support'],
+        permissions: ['manage_users'],
+        last_login: null,
+        created_at: '2024-03-20T09:00:00Z',
+        updated_at: '2024-03-20T09:00:00Z',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createUser(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/users`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    const body = JSON.parse((fetchMock.mock.calls[0]?.[1]?.body as string) ?? '{}');
+    expect(body).toEqual({
+      first_name: 'Cristina',
+      last_name: 'Marin',
+      email: 'cristina@dacars.ro',
+      username: 'cristina.marin',
+      password: 'SuperSecret123',
+      roles: ['admin', 'support'],
+      super_user: false,
+      manage_supers: true,
+    });
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates a user preserving provided fields and removing undefined ones', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload: Parameters<ApiClient['updateUser']>[1] = {
+      first_name: 'Matei',
+      last_name: undefined,
+      email: 'matei@dacars.ro',
+      username: undefined,
+      roles: ['support'],
+      manage_supers: false,
+      super_user: undefined,
+      password: undefined,
+    };
+
+    const apiResponse: ApiItemResult<User> = {
+      data: {
+        id: 7,
+        first_name: 'Matei',
+        last_name: 'Popescu',
+        email: 'matei@dacars.ro',
+        username: 'matei.popescu',
+        avatar: null,
+        super_user: false,
+        manage_supers: false,
+        roles: ['support'],
+        permissions: [],
+        last_login: null,
+        created_at: '2024-02-01T08:00:00Z',
+        updated_at: '2024-03-22T08:00:00Z',
+      },
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateUser(7, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/users/7`,
+      expect.objectContaining({
+        method: 'PUT',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    const body = JSON.parse((fetchMock.mock.calls[0]?.[1]?.body as string) ?? '{}');
+    expect(body).toEqual({
+      first_name: 'Matei',
+      email: 'matei@dacars.ro',
+      roles: ['support'],
+      manage_supers: false,
+    });
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('promotes a user to super admin', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiMessageResponse = { message: 'Utilizatorul a devenit super admin' };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.makeUserSuper(10);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/users/10/super`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('revokes a user super admin status', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiMessageResponse = { message: 'Utilizatorul nu mai este super admin' };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.removeUserSuper(10);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/users/10/super`,
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('deletes a user and returns confirmation', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const apiResponse: ApiDeleteResponse = { message: 'Utilizatorul a fost șters' };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.deleteUser(42);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/users/42`,
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+});

--- a/lib/__tests__/apiWheelOfFortune.test.ts
+++ b/lib/__tests__/apiWheelOfFortune.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from '@/lib/api';
+import type { ApiItemResult } from '@/types/api';
+import type { WheelPrize } from '@/types/wheel';
+
+describe('ApiClient admin wheel of fortune management', () => {
+  const baseURL = 'https://admin-api.dacars.test';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('creates a wheel prize using sanitized payload and admin headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      period_id: 4,
+      title: 'Voucher cadou 10%',
+      description: undefined,
+      amount: null,
+      color: '#1fb58f',
+      probability: 12,
+      type: 'discount',
+    } as const;
+
+    const apiResponse: ApiItemResult<WheelPrize> = {
+      data: {
+        id: 42,
+        period_id: 4,
+        title: 'Voucher cadou 10%',
+        color: '#1fb58f',
+        probability: 12,
+        type: 'discount',
+      } as WheelPrize,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.createWheelOfFortune(payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/wheel-of-fortunes`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          period_id: 4,
+          title: 'Voucher cadou 10%',
+          amount: null,
+          color: '#1fb58f',
+          probability: 12,
+          type: 'discount',
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+
+  it('updates a wheel prize keeping only provided fields and admin auth headers', async () => {
+    const client = new ApiClient(baseURL);
+    client.setToken('admin-token');
+
+    const payload = {
+      period_id: 6,
+      title: 'Voucher weekend gratuit',
+      description: 'Oferta disponibilă doar în luna decembrie.',
+      amount: 150,
+      color: '#1f3fb5',
+      probability: 5,
+    } as const;
+
+    const apiResponse: ApiItemResult<WheelPrize> = {
+      data: {
+        id: 42,
+        period_id: 6,
+        title: 'Voucher weekend gratuit',
+        description: 'Oferta disponibilă doar în luna decembrie.',
+        amount: 150,
+      } as WheelPrize,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(apiResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await client.updateWheelOfFortune(42, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseURL}/wheel-of-fortunes/42`,
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          period_id: 6,
+          title: 'Voucher weekend gratuit',
+          description: 'Oferta disponibilă doar în luna decembrie.',
+          amount: 150,
+          color: '#1f3fb5',
+          probability: 5,
+        }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer admin-token',
+          'X-API-KEY': 'kSqh88TvUXNl6TySfXaXnxbv1jeorTJt',
+        }),
+        credentials: 'omit',
+      }),
+    );
+
+    expect(result).toEqual(apiResponse);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Vitest coverage for admin blog categories to ensure filter sanitization and CRUD requests send trimmed payloads with auth headers
- cover blog tags listing and mutations to confirm undefined fields are stripped while preserving admin authentication context
- exercise blog post listing, retrieval, JSON, and FormData flows to validate include handling, payload cleanup, and authentication propagation in the ApiClient

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68ddaeb39e3c8329ae0596710cc600bf