### PR TITLE
Enable touch selection on admin calendar

### DIFF
--- a/components/admin/CarRentalCalendar.tsx
+++ b/components/admin/CarRentalCalendar.tsx
@@ -621,7 +621,10 @@ const CarRentalCalendar: React.FC = () => {
         setDateSelection(range, false);
     };
 
-    const findTouchById = (touchList: TouchList, identifier: number | null): Touch | null => {
+    const findTouchById = (
+        touchList: TouchList | React.TouchList,
+        identifier: number | null,
+    ): (Touch | React.Touch) | null => {
         if (identifier == null) return null;
         for (let i = 0; i < touchList.length; i += 1) {
             const touch = touchList.item(i);


### PR DESCRIPTION
## Summary
- add touch interaction state to the admin calendar so date drag operations are tracked on touch devices
- implement touch handlers on the date header and car rows to allow selecting continuous date ranges on phones
- reuse a shared helper to translate touch coordinates into date indexes for consistent behaviour across inputs

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68de49eea9288329aeb09fcac4e18d10