### PR TITLE
Add limited email restriction support to coupons admin page

### DIFF
--- a/types/coupon.ts
+++ b/types/coupon.ts
@@ -14,6 +14,7 @@ export interface Coupon {
   is_unlimited_expires?: boolean | null;
   expires_at?: string | null;
   limit?: number | null;
+  limited_to_email?: string | null;
   used?: number | null;
   created_at?: string | null;
   updated_at?: string | null;
@@ -28,6 +29,7 @@ export type CouponPayload = Partial<{
   is_unlimited_expires: boolean;
   expires_at: string | null;
   limit: number | null;
+  limited_to_email: string | null;
   used: number | null;
 }> & Record<string, unknown>;
 


### PR DESCRIPTION
## Summary
- add a field in the coupons admin form to capture an optional limited_to_email value with validation and submission
- display the limited_to_email attribute in the coupons table and details for easier management
- extend coupon typings to include the limited_to_email property in API payloads

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68df00ff5d54832982d7168c502f2120