### PR TITLE
Add coupon validity window management

### DIFF
--- a/lib/__tests__/apiCoupons.test.ts
+++ b/lib/__tests__/apiCoupons.test.ts
@@ -102,6 +102,9 @@ describe('ApiClient coupons management', () => {
       is_unlimited: false,
       expires_at: undefined,
       limit: null,
+      is_date_valid: true,
+      valid_start_date: '2025-05-01T00:00:00',
+      valid_end_date: '2025-05-31T23:59:59',
     };
 
     const apiResponse: ApiItemResult<Coupon> = {
@@ -112,6 +115,9 @@ describe('ApiClient coupons management', () => {
         value: 15,
         is_unlimited: false,
         limit: null,
+        is_date_valid: true,
+        valid_start_date: '2025-05-01T00:00:00',
+        valid_end_date: '2025-05-31T23:59:59',
       },
     };
 
@@ -136,6 +142,9 @@ describe('ApiClient coupons management', () => {
       value: 15,
       is_unlimited: false,
       limit: null,
+      is_date_valid: true,
+      valid_start_date: '2025-05-01T00:00:00',
+      valid_end_date: '2025-05-31T23:59:59',
     });
 
     expect(result).toEqual(apiResponse);
@@ -149,6 +158,9 @@ describe('ApiClient coupons management', () => {
       value: 35,
       is_unlimited: true,
       limit: undefined,
+      is_date_valid: false,
+      valid_start_date: undefined,
+      valid_end_date: null,
     };
 
     const apiResponse: ApiItemResult<Coupon> = {
@@ -158,6 +170,7 @@ describe('ApiClient coupons management', () => {
         type: 'percent',
         value: 35,
         is_unlimited: true,
+        is_date_valid: false,
       },
     };
 
@@ -183,6 +196,8 @@ describe('ApiClient coupons management', () => {
     expect(parsedBody).toEqual({
       value: 35,
       is_unlimited: true,
+      is_date_valid: false,
+      valid_end_date: null,
     });
 
     expect(result).toEqual(apiResponse);
@@ -214,6 +229,9 @@ describe('ApiClient coupons management', () => {
     const params: CouponQuickValidationParams = {
       code: 'SUMMER20',
       sub_total: 199.99,
+      start_date: '2025-05-12T09:00',
+      end_date: '2025-05-18T09:00',
+      customer_email: 'vip@example.com',
       context: 'booking',
     };
     const apiResponse: CouponQuickValidationResponse = {
@@ -233,7 +251,15 @@ describe('ApiClient coupons management', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe(`${baseURL}/coupons/validate?code=SUMMER20&sub_total=199.99&context=booking`);
+    const expectedParams = new URLSearchParams();
+    expectedParams.append('code', 'SUMMER20');
+    expectedParams.append('sub_total', '199.99');
+    expectedParams.append('start_date', '2025-05-12T09:00');
+    expectedParams.append('end_date', '2025-05-18T09:00');
+    expectedParams.append('customer_email', 'vip@example.com');
+    expectedParams.append('context', 'booking');
+
+    expect(url).toBe(`${baseURL}/coupons/validate?${expectedParams.toString()}`);
     expect(init?.method).toBeUndefined();
     expect(result).toEqual(apiResponse);
   });

--- a/types/coupon.ts
+++ b/types/coupon.ts
@@ -13,6 +13,9 @@ export interface Coupon {
   is_unlimited: boolean;
   is_unlimited_expires?: boolean | null;
   expires_at?: string | null;
+  is_date_valid?: boolean | null;
+  valid_start_date?: string | null;
+  valid_end_date?: string | null;
   limit?: number | null;
   limited_to_email?: string | null;
   used?: number | null;
@@ -28,6 +31,9 @@ export type CouponPayload = Partial<{
   is_unlimited: boolean;
   is_unlimited_expires: boolean;
   expires_at: string | null;
+  is_date_valid: boolean;
+  valid_start_date: string | null;
+  valid_end_date: string | null;
   limit: number | null;
   limited_to_email: string | null;
   used: number | null;
@@ -47,6 +53,9 @@ export interface CouponListParams {
 export interface CouponQuickValidationParams {
   code: string;
   sub_total?: number | string;
+  start_date?: string | null;
+  end_date?: string | null;
+  customer_email?: string | null;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
- expose coupon validity window fields in shared types and API tests
- extend the admin coupons form to configure booking interval restrictions and validate inputs
- update coupon API tests to cover the new request fields and encoded quick-validation URLs

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e028e090148329872e384d17fe137c