### PR TITLE
Add comprehensive client public flow tests

### DIFF
--- a/app/admin/users/__tests__/usersAdminPage.test.tsx
+++ b/app/admin/users/__tests__/usersAdminPage.test.tsx
@@ -1,0 +1,331 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import UsersAdminPage from "@/app/admin/users/page";
+import type { User } from "@/types/auth";
+
+const getUsersMock = vi.hoisted(() => vi.fn());
+const createUserMock = vi.hoisted(() => vi.fn());
+const updateUserMock = vi.hoisted(() => vi.fn());
+const deleteUserMock = vi.hoisted(() => vi.fn());
+const makeUserSuperMock = vi.hoisted(() => vi.fn());
+const removeUserSuperMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api", () => ({
+  __esModule: true,
+  default: {
+    getUsers: (...args: unknown[]) => getUsersMock(...args),
+    createUser: (...args: unknown[]) => createUserMock(...args),
+    updateUser: (...args: unknown[]) => updateUserMock(...args),
+    deleteUser: (...args: unknown[]) => deleteUserMock(...args),
+    makeUserSuper: (...args: unknown[]) => makeUserSuperMock(...args),
+    removeUserSuper: (...args: unknown[]) => removeUserSuperMock(...args),
+  },
+}));
+
+const baseUser: User = {
+  id: 1,
+  first_name: "Ana",
+  last_name: "Pop",
+  email: "ana@example.com",
+  username: "ana",
+  avatar: null,
+  super_user: false,
+  manage_supers: false,
+  roles: ["admin"],
+  permissions: [],
+  last_login: "2024-10-12T10:00:00Z",
+  created_at: "2024-10-01T08:00:00Z",
+  updated_at: "2024-10-20T09:00:00Z",
+};
+
+const renderPage = async (users: User[] = [baseUser]) => {
+  getUsersMock.mockResolvedValue({ data: users });
+  render(<UsersAdminPage />);
+  await waitFor(() => {
+    expect(getUsersMock).toHaveBeenCalled();
+  });
+};
+
+describe("UsersAdminPage", () => {
+  beforeEach(() => {
+    getUsersMock.mockReset();
+    createUserMock.mockReset();
+    updateUserMock.mockReset();
+    deleteUserMock.mockReset();
+    makeUserSuperMock.mockReset();
+    removeUserSuperMock.mockReset();
+  });
+
+  it("loads and renders the users list, supporting manual refresh", async () => {
+    await renderPage();
+
+    expect(await screen.findByText("Ana Pop")).toBeInTheDocument();
+    expect(screen.getByText("ID: 1")).toBeInTheDocument();
+    expect(screen.getByText("ana@example.com")).toBeInTheDocument();
+    expect(screen.getByText("ana")).toBeInTheDocument();
+    expect(screen.getByText("admin")).toBeInTheDocument();
+
+    getUsersMock.mockClear();
+    const user = userEvent.setup();
+    const [refreshButton] = screen.getAllByRole("button", {
+      name: "Reîmprospătează",
+    });
+    await user.click(refreshButton);
+
+    await waitFor(() => {
+      expect(getUsersMock).toHaveBeenCalledTimes(1);
+      expect(getUsersMock).toHaveBeenCalledWith({
+        search: undefined,
+        limit: 100,
+        includeRoles: true,
+        sort: "-id",
+      });
+    });
+  });
+
+  it("filters users based on the search form and supports reset", async () => {
+    await renderPage();
+
+    const user = userEvent.setup();
+    getUsersMock.mockClear();
+
+    const [searchInput] = screen.getAllByRole("textbox", {
+      name: "Caută utilizatori",
+    });
+    await user.type(searchInput, "Manager");
+    const [searchButton] = screen.getAllByRole("button", { name: "Caută" });
+    await user.click(searchButton);
+
+    await waitFor(() => {
+      expect(getUsersMock).toHaveBeenCalledWith({
+        search: "Manager",
+        limit: 100,
+        includeRoles: true,
+        sort: "-id",
+      });
+    });
+
+    getUsersMock.mockClear();
+    const [resetButton] = screen.getAllByRole("button", { name: "Resetare" });
+    await user.click(resetButton);
+
+    await waitFor(() => {
+      expect(searchInput).toHaveValue("");
+      expect(getUsersMock).toHaveBeenCalledWith({
+        search: undefined,
+        limit: 100,
+        includeRoles: true,
+        sort: "-id",
+      });
+    });
+  });
+
+  it("validates the add user form and sends the correct payload", async () => {
+    await renderPage();
+
+    const user = userEvent.setup();
+    const [openModalButton] = screen.getAllByRole("button", {
+      name: /Adaugă utilizator/,
+    });
+    await user.click(openModalButton);
+
+    const submitButton = screen
+      .getAllByRole("button", { name: /Adaugă utilizator/ })
+      .find((button) => button.getAttribute("type") === "submit");
+    expect(submitButton).toBeDefined();
+
+    await user.click(submitButton!);
+    expect(
+      screen.getByText("Introdu cel puțin un email sau un nume de utilizator."),
+    ).toBeInTheDocument();
+
+    const emailField = screen.getByLabelText("Email");
+    const usernameField = screen.getByLabelText("Nume utilizator");
+    await user.type(emailField, "new.user@example.com");
+    await user.type(usernameField, "newuser");
+
+    const passwordField = screen.getByLabelText("Parolă");
+    await user.type(passwordField, "short");
+    await user.click(submitButton!);
+    expect(
+      screen.getByText("Parola trebuie să aibă cel puțin 8 caractere."),
+    ).toBeInTheDocument();
+
+    await user.clear(passwordField);
+    await user.type(passwordField, "supersecure8");
+    await user.type(screen.getByLabelText("Prenume"), "Maria");
+    await user.type(screen.getByLabelText("Nume"), "Ionescu");
+    await user.type(screen.getByLabelText("Roluri"), "admin, manager");
+
+    const superCheckbox = screen.getByRole("checkbox", {
+      name: "Super utilizator",
+    });
+    const manageCheckbox = screen.getByRole("checkbox", {
+      name: "Poate gestiona super utilizatorii",
+    });
+    await user.click(superCheckbox);
+    await user.click(manageCheckbox);
+
+    createUserMock.mockResolvedValue({ data: { id: 2 } });
+    getUsersMock.mockResolvedValueOnce({ data: [baseUser] });
+
+    await user.click(submitButton!);
+
+    await waitFor(() => {
+      expect(createUserMock).toHaveBeenCalledTimes(1);
+      expect(createUserMock).toHaveBeenCalledWith({
+        first_name: "Maria",
+        last_name: "Ionescu",
+        email: "new.user@example.com",
+        username: "newuser",
+        password: "supersecure8",
+        super_user: true,
+        manage_supers: true,
+        roles: ["admin", "manager"],
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Completează datele de bază/)).not.toBeInTheDocument();
+    });
+  });
+
+  it("prefills and submits the edit user form", async () => {
+    const editableUser: User = {
+      ...baseUser,
+      id: 3,
+      first_name: "Ioana",
+      last_name: "Georgescu",
+      super_user: true,
+      manage_supers: true,
+      roles: ["admin", "support"],
+    };
+    await renderPage([editableUser]);
+
+    const user = userEvent.setup();
+    const [editButton] = screen.getAllByRole("button", {
+      name: `Editează ${editableUser.first_name} ${editableUser.last_name}`,
+    });
+    await user.click(editButton);
+
+    const firstNameField = screen.getByLabelText("Prenume");
+    const lastNameField = screen.getByLabelText("Nume");
+    const rolesField = screen.getByLabelText("Roluri");
+    const superCheckbox = screen.getByRole("checkbox", {
+      name: "Super utilizator",
+    });
+    const manageCheckbox = screen.getByRole("checkbox", {
+      name: "Poate gestiona super utilizatorii",
+    });
+
+    expect(firstNameField).toHaveValue("Ioana");
+    expect(lastNameField).toHaveValue("Georgescu");
+    expect(screen.getByLabelText("Email")).toHaveValue("ana@example.com");
+    expect(screen.getByLabelText("Nume utilizator")).toHaveValue("ana");
+    expect(rolesField).toHaveValue("admin, support");
+    expect(superCheckbox).toBeChecked();
+    expect(manageCheckbox).toBeChecked();
+
+    await user.clear(firstNameField);
+    await user.type(firstNameField, "Ioana-Maria");
+    await user.clear(lastNameField);
+    await user.type(lastNameField, "Popescu");
+    await user.clear(rolesField);
+    await user.type(rolesField, "support");
+    await user.click(superCheckbox);
+    await user.click(manageCheckbox);
+
+    const [saveButton] = screen.getAllByRole("button", {
+      name: "Salvează modificările",
+    });
+
+    updateUserMock.mockResolvedValue({ data: { id: editableUser.id } });
+    getUsersMock.mockResolvedValueOnce({ data: [editableUser] });
+
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(updateUserMock).toHaveBeenCalledTimes(1);
+      expect(updateUserMock).toHaveBeenCalledWith(editableUser.id, {
+        first_name: "Ioana-Maria",
+        last_name: "Popescu",
+        email: "ana@example.com",
+        username: "ana",
+        super_user: false,
+        manage_supers: false,
+        roles: ["support"],
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Completează datele de bază/)).not.toBeInTheDocument();
+    });
+  });
+
+  it("confirms and deletes a user", async () => {
+    await renderPage();
+
+    const user = userEvent.setup();
+    const rows = screen.getAllByRole("row");
+    const targetRow = rows.find((row) =>
+      within(row).queryByText("Ana Pop"),
+    );
+    expect(targetRow).toBeDefined();
+    const deleteButton = within(targetRow!).getByRole("button", {
+      name: "Șterge Ana Pop",
+    });
+    await user.click(deleteButton);
+
+    const [confirmationMessage] = screen.getAllByText(
+      /Ești sigur că vrei să ștergi contul/i,
+    );
+    expect(confirmationMessage).toBeInTheDocument();
+
+    deleteUserMock.mockResolvedValue({ message: "Deleted" });
+    getUsersMock.mockResolvedValueOnce({ data: [] });
+
+    const [confirmDeleteButton] = screen.getAllByRole("button", {
+      name: "Șterge utilizator",
+    });
+    await user.click(confirmDeleteButton);
+
+    await waitFor(() => {
+      expect(deleteUserMock).toHaveBeenCalledTimes(1);
+      expect(deleteUserMock).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it("toggles the super user switch on and off", async () => {
+    const users: User[] = [
+      { ...baseUser, id: 10, first_name: "Paul", super_user: false },
+      { ...baseUser, id: 11, first_name: "Laura", super_user: true },
+    ];
+    await renderPage(users);
+
+    const user = userEvent.setup();
+
+    makeUserSuperMock.mockResolvedValue({ message: "ok" });
+    removeUserSuperMock.mockResolvedValue({ message: "ok" });
+
+    const activateSwitch = screen.getByRole("switch", {
+      name: "Activează statutul de super utilizator pentru Paul Pop",
+    });
+    await user.click(activateSwitch);
+
+    await waitFor(() => {
+      expect(makeUserSuperMock).toHaveBeenCalledWith(10);
+      expect(activateSwitch).toHaveAttribute("aria-checked", "true");
+    });
+
+    const deactivateSwitch = screen.getByRole("switch", {
+      name: "Dezactivează statutul de super utilizator pentru Laura Pop",
+    });
+    await user.click(deactivateSwitch);
+
+    await waitFor(() => {
+      expect(removeUserSuperMock).toHaveBeenCalledWith(11);
+      expect(deactivateSwitch).toHaveAttribute("aria-checked", "false");
+    });
+  });
+});

--- a/components/__tests__/clientBookingFlow.test.tsx
+++ b/components/__tests__/clientBookingFlow.test.tsx
@@ -1,0 +1,318 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ReservationPage from '@/app/checkout/page';
+import HeroSection from '@/components/HeroSection';
+import CarsPageClient from '@/components/cars/CarsPageClient';
+import { BookingContext, defaultBooking } from '@/context/booking-store';
+import { LocaleProvider } from '@/context/LocaleContext';
+import type { BookingData } from '@/types/booking';
+import type { ApiCar, Car } from '@/types/car';
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+let searchParams = new URLSearchParams();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: pushMock,
+    replace: replaceMock,
+  }),
+  usePathname: () => '/cars',
+  useSearchParams: () => searchParams,
+}));
+type ApiClientMock = {
+  getCarCategories: ReturnType<typeof vi.fn>;
+  getCarsByDateCriteria: ReturnType<typeof vi.fn>;
+  setLanguage: ReturnType<typeof vi.fn>;
+  getServices: ReturnType<typeof vi.fn>;
+  checkCarAvailability: ReturnType<typeof vi.fn>;
+  getCarForBooking: ReturnType<typeof vi.fn>;
+  validateDiscountCode: ReturnType<typeof vi.fn>;
+  quotePrice: ReturnType<typeof vi.fn>;
+  createBooking: ReturnType<typeof vi.fn>;
+};
+
+vi.mock('@/lib/api', () => {
+  const mock: ApiClientMock = {
+    getCarCategories: vi.fn(),
+    getCarsByDateCriteria: vi.fn(),
+    setLanguage: vi.fn(),
+    getServices: vi.fn(),
+    checkCarAvailability: vi.fn(),
+    getCarForBooking: vi.fn(),
+    validateDiscountCode: vi.fn(),
+    quotePrice: vi.fn(),
+    createBooking: vi.fn(),
+  };
+  (globalThis as { __apiClientMock?: ApiClientMock }).__apiClientMock = mock;
+  return {
+    apiClient: mock,
+    default: mock,
+  };
+});
+
+type WheelStorageMock = {
+  getStoredWheelPrize: ReturnType<typeof vi.fn>;
+  isStoredWheelPrizeActive: ReturnType<typeof vi.fn>;
+  clearStoredWheelPrize: ReturnType<typeof vi.fn>;
+  storeWheelPrize: ReturnType<typeof vi.fn>;
+};
+
+vi.mock('@/lib/wheelStorage', () => {
+  const mock: WheelStorageMock = {
+    getStoredWheelPrize: vi.fn(() => null),
+    isStoredWheelPrizeActive: vi.fn(() => false),
+    clearStoredWheelPrize: vi.fn(),
+    storeWheelPrize: vi.fn(),
+  };
+  (globalThis as { __wheelStorageMock?: WheelStorageMock }).__wheelStorageMock = mock;
+  return mock;
+});
+
+const apiClientMock = (globalThis as { __apiClientMock: ApiClientMock }).__apiClientMock;
+const wheelStorageMock = (globalThis as { __wheelStorageMock: WheelStorageMock }).__wheelStorageMock;
+
+const mockApiCar: ApiCar = {
+  id: 101,
+  name: 'Dacia Logan',
+  type: { id: 5, name: 'Sedan' },
+  transmission: { id: 2, name: 'Manuală' },
+  fuel: { id: 1, name: 'Benzină' },
+  number_of_seats: 5,
+  rental_rate: 55,
+  rental_rate_casco: 70,
+  days: 4,
+  deposit: 100,
+  total_deposit: 220,
+  total_without_deposit: 280,
+  image: '/images/test-car.jpg',
+  images: ['/images/test-car.jpg'],
+  avg_review: 4.8,
+  content: 'Autovehicul pentru test',
+};
+
+const mappedCar: Car = {
+  id: mockApiCar.id,
+  name: mockApiCar.name ?? 'Autovehicul',
+  type: mockApiCar.type?.name ?? 'Sedan',
+  typeId: mockApiCar.type?.id ?? null,
+  image: '/images/test-car.jpg',
+  gallery: ['/images/test-car.jpg'],
+  price: 55,
+  rental_rate: String(mockApiCar.rental_rate ?? 55),
+  rental_rate_casco: String(mockApiCar.rental_rate_casco ?? 70),
+  days: Number(mockApiCar.days ?? 4),
+  deposit: Number(mockApiCar.deposit ?? 0),
+  total_deposit: String(mockApiCar.total_deposit ?? 0),
+  total_without_deposit: String(mockApiCar.total_without_deposit ?? 0),
+  available: true,
+  features: {
+    passengers: 5,
+    transmission: mockApiCar.transmission && typeof mockApiCar.transmission === 'object'
+      ? mockApiCar.transmission.name ?? 'Manuală'
+      : 'Manuală',
+    transmissionId: mockApiCar.transmission && typeof mockApiCar.transmission === 'object'
+      ? mockApiCar.transmission.id ?? null
+      : null,
+    fuel: mockApiCar.fuel && typeof mockApiCar.fuel === 'object'
+      ? mockApiCar.fuel.name ?? 'Benzină'
+      : 'Benzină',
+    fuelId: mockApiCar.fuel && typeof mockApiCar.fuel === 'object'
+      ? mockApiCar.fuel.id ?? null
+      : null,
+    doors: 4,
+    luggage: 2,
+  },
+  rating: Number(mockApiCar.avg_review ?? 0),
+  description: mockApiCar.content ?? '',
+  specs: [],
+};
+
+type RenderOptions = {
+  booking?: Partial<BookingData>;
+  setBooking?: ReturnType<typeof vi.fn>;
+};
+
+const renderWithProviders = (
+  ui: React.ReactElement,
+  options: RenderOptions = {},
+) => {
+  const bookingData: BookingData = {
+    ...defaultBooking,
+    appliedOffers: [],
+    ...options.booking,
+  };
+  const setBooking = options.setBooking ?? vi.fn();
+  return {
+    setBooking,
+    ...render(
+      <LocaleProvider initialLocale="ro">
+        <BookingContext.Provider value={{ booking: bookingData, setBooking }}>
+          {ui}
+        </BookingContext.Provider>
+      </LocaleProvider>,
+    ),
+  };
+};
+
+beforeEach(() => {
+  pushMock.mockReset();
+  replaceMock.mockReset();
+  searchParams = new URLSearchParams();
+  window.history.replaceState({}, '', '/');
+
+  Object.values(apiClientMock).forEach((fn) => fn.mockReset());
+  wheelStorageMock.getStoredWheelPrize.mockReturnValue(null);
+  wheelStorageMock.isStoredWheelPrizeActive.mockReturnValue(false);
+  wheelStorageMock.clearStoredWheelPrize.mockReset();
+
+  apiClientMock.getCarCategories.mockResolvedValue({ data: [{ id: 1, name: 'SUV' }] });
+  apiClientMock.getCarsByDateCriteria.mockResolvedValue({
+    data: [mockApiCar],
+    meta: { total: 1, last_page: 1 },
+  });
+  apiClientMock.getServices.mockResolvedValue({ data: [] });
+  apiClientMock.checkCarAvailability.mockResolvedValue({ available: true });
+  apiClientMock.getCarForBooking.mockResolvedValue({ data: mockApiCar, available: true });
+  apiClientMock.validateDiscountCode.mockResolvedValue({ valid: true, data: null });
+  apiClientMock.quotePrice.mockResolvedValue({
+    price_per_day: 70,
+    base_price: 70,
+    sub_total: 280,
+    total: 280,
+    total_services: 0,
+    offers_discount: 0,
+    coupon_amount: 0,
+    total_before_wheel_prize: 280,
+    wheel_prize_discount: 0,
+    applied_offers: [],
+  });
+  apiClientMock.createBooking.mockResolvedValue({ data: { id: 1 } });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Fluxul de închiriere pentru clienți', () => {
+  it('permite completarea formularului principal și navigarea spre lista de mașini', async () => {
+    const user = userEvent.setup();
+    const setBooking = vi.fn();
+    renderWithProviders(<HeroSection />, { setBooking });
+
+    await waitFor(() => expect(apiClientMock.getCarCategories).toHaveBeenCalled());
+
+    const pickupInput = screen.getByLabelText(/Data ridicare/i);
+    const returnInput = screen.getByLabelText(/Data returnare/i);
+    const carTypeSelect = screen.getByLabelText(/Tip mașină/i);
+    const submitButton = screen.getByRole('button', { name: /Caută mașini/i });
+    const form = submitButton.closest('form');
+    if (!form) {
+      throw new Error('Nu am găsit formularul de căutare');
+    }
+
+    await user.clear(pickupInput);
+    await user.type(pickupInput, '2025-06-10T10:00');
+    await user.clear(returnInput);
+    await user.type(returnInput, '2025-06-12T10:00');
+    await user.selectOptions(carTypeSelect, '1');
+
+    fireEvent.submit(form);
+
+    await waitFor(() => expect(pushMock).toHaveBeenCalledTimes(1));
+    const destination = pushMock.mock.calls[0][0] as string;
+    expect(destination).toContain('/cars?');
+    const params = new URLSearchParams(destination.split('?')[1]);
+    expect(params.get('start_date')).toBe('2025-06-10T10:00');
+    expect(params.get('end_date')).toBe('2025-06-12T10:00');
+    expect(params.get('car_type')).toBe('1');
+    expect(params.get('location')).toBe('otopeni');
+  });
+
+  it('permite selectarea unei mașini și continuarea către checkout', async () => {
+    const user = userEvent.setup();
+    const setBooking = vi.fn();
+    const query = new URLSearchParams({
+      start_date: '2025-07-01T08:00',
+      end_date: '2025-07-05T10:00',
+    });
+    searchParams = new URLSearchParams(query.toString());
+    window.history.replaceState({}, '', `/cars?${query.toString()}`);
+
+    renderWithProviders(<CarsPageClient />, { setBooking });
+
+    await waitFor(() => expect(apiClientMock.getCarsByDateCriteria).toHaveBeenCalled());
+
+    await screen.findByText(mockApiCar.name ?? 'Dacia Logan', undefined, {
+      timeout: 8000,
+    });
+
+    const reserveNoDeposit = await screen.findByText(
+      /Rezervă fără garanție/i,
+      { selector: 'button' },
+    );
+
+    await user.click(reserveNoDeposit);
+
+    expect(setBooking).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startDate: '2025-07-01T08:00',
+        endDate: '2025-07-05T10:00',
+        withDeposit: false,
+        selectedCar: expect.objectContaining({ id: mockApiCar.id, name: mockApiCar.name }),
+      }),
+    );
+    expect(pushMock).toHaveBeenCalledWith('/checkout');
+
+    pushMock.mockClear();
+
+    const reserveWithDeposit = screen.getByText(/Rezervă cu garanție/i, {
+      selector: 'button',
+    });
+    await user.click(reserveWithDeposit);
+
+    expect(setBooking).toHaveBeenCalledWith(
+      expect.objectContaining({
+        withDeposit: true,
+        selectedCar: expect.objectContaining({ id: mockApiCar.id }),
+      }),
+    );
+    expect(pushMock).toHaveBeenCalledWith('/checkout');
+  }, 15000);
+
+  it('păstrează opțiunile din checkout și permite schimbarea garanției', async () => {
+    const user = userEvent.setup();
+    const setBooking = vi.fn();
+    localStorage.clear();
+
+    renderWithProviders(<ReservationPage />, {
+      setBooking,
+      booking: {
+        startDate: '2025-08-01T09:00',
+        endDate: '2025-08-05T10:00',
+        withDeposit: false,
+        selectedCar: mappedCar,
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/Rezumatul rezervării/i)).toBeInTheDocument(),
+    );
+
+    const depositWithout = screen.getByLabelText(/Fără garanție/i) as HTMLInputElement;
+    const depositWith = screen.getByLabelText(/Cu garanție/i);
+
+    expect(depositWithout).toBeChecked();
+
+    await user.click(depositWith);
+
+    await waitFor(() =>
+      expect(setBooking).toHaveBeenCalledWith(
+        expect.objectContaining({ withDeposit: true }),
+      ),
+    );
+  });
+});

--- a/components/__tests__/clientHomeExperience.test.tsx
+++ b/components/__tests__/clientHomeExperience.test.tsx
@@ -1,0 +1,333 @@
+import React from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import HeroSection from '@/components/HeroSection';
+import FleetSection from '@/components/FleetSection';
+import ContactSection from '@/components/ContactSection';
+import HomePageClient from '@/components/home/HomePageClient';
+import { BookingContext, defaultBooking } from '@/context/booking-store';
+import { LocaleProvider } from '@/context/LocaleContext';
+import type { BookingContextType, BookingData } from '@/types/booking';
+import type { ApiCar } from '@/types/car';
+import type { WheelOfFortunePeriod } from '@/types/wheel';
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+let currentSearchParams = new URLSearchParams();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: pushMock,
+    replace: replaceMock,
+  }),
+  useSearchParams: () => currentSearchParams,
+  usePathname: () => '/',
+}));
+
+type ClientApiMock = {
+  getCarCategories: ReturnType<typeof vi.fn>;
+  getHomePageCars: ReturnType<typeof vi.fn>;
+  getOffers: ReturnType<typeof vi.fn>;
+  getWheelOfFortunePeriods: ReturnType<typeof vi.fn>;
+  setLanguage: ReturnType<typeof vi.fn>;
+};
+
+vi.mock('@/lib/api', () => {
+  const mock: ClientApiMock = {
+    getCarCategories: vi.fn(),
+    getHomePageCars: vi.fn(),
+    getOffers: vi.fn(),
+    getWheelOfFortunePeriods: vi.fn(),
+    setLanguage: vi.fn(),
+  };
+  (globalThis as { __clientApiMock?: ClientApiMock }).__clientApiMock = mock;
+  return {
+    __esModule: true,
+    apiClient: mock,
+    default: mock,
+  };
+});
+
+vi.mock('@/components/ElfsightWidget', () => ({
+  __esModule: true,
+  default: () => <div data-testid="elfsight-widget">Elfsight</div>,
+}));
+
+vi.mock('@/components/WheelOfFortune', () => ({
+  __esModule: true,
+  default: ({ onClose }: { onClose?: () => void }) => (
+    <div data-testid="wheel-popup">
+      <p>Roata norocului este disponibilă</p>
+      <button type="button" onClick={onClose}>
+        Închide roata
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/components/LazyMap', () => ({
+  __esModule: true,
+  default: () => <div data-testid="lazy-map">Harta locației</div>,
+}));
+
+const apiClientMock = (globalThis as { __clientApiMock: ClientApiMock }).__clientApiMock;
+
+const baseCar: ApiCar = {
+  id: 101,
+  name: 'Dacia Logan',
+  type: { id: 1, name: 'Sedan' },
+  transmission: { id: 2, name: 'Manuală' },
+  fuel: { id: 3, name: 'Benzină' },
+  number_of_seats: 5,
+  rental_rate: 55,
+  rental_rate_casco: 75,
+  days: 4,
+  deposit: 100,
+  total_deposit: 200,
+  total_without_deposit: 220,
+  image: '/images/test-car.jpg',
+  images: ['/images/test-car.jpg'],
+  avg_review: 4.7,
+  content: 'Autovehicul pentru testare',
+};
+
+type RenderOptions = {
+  booking?: Partial<BookingData>;
+  setBooking?: BookingContextType['setBooking'];
+};
+
+const renderWithProviders = (
+  ui: React.ReactElement,
+  options: RenderOptions = {},
+) => {
+  const booking: BookingData = {
+    ...defaultBooking,
+    appliedOffers: [],
+    ...options.booking,
+  };
+  const setBooking = options.setBooking ?? vi.fn();
+
+  return {
+    setBooking,
+    ...render(
+      <LocaleProvider initialLocale="ro">
+        <BookingContext.Provider value={{ booking, setBooking }}>
+          {ui}
+        </BookingContext.Provider>
+      </LocaleProvider>,
+    ),
+  };
+};
+
+const waitForCarCategories = async () => {
+  await waitFor(() => expect(apiClientMock.getCarCategories).toHaveBeenCalled());
+};
+
+const waitForHomePageCars = async () => {
+  await waitFor(() => expect(apiClientMock.getHomePageCars).toHaveBeenCalled());
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+beforeEach(() => {
+  pushMock.mockReset();
+  replaceMock.mockReset();
+  currentSearchParams = new URLSearchParams();
+
+  apiClientMock.getCarCategories.mockReset();
+  apiClientMock.getHomePageCars.mockReset();
+  apiClientMock.getWheelOfFortunePeriods.mockReset();
+  apiClientMock.setLanguage.mockReset();
+
+  apiClientMock.getCarCategories.mockResolvedValue({
+    data: [
+      { id: 7, name: 'SUV' },
+      { id: 9, name: 'Compactă' },
+    ],
+  });
+
+  apiClientMock.getHomePageCars.mockResolvedValue({
+    data: [
+      baseCar,
+      {
+        ...baseCar,
+        id: 202,
+        name: 'Renault Clio',
+        categories: [{ id: 2, name: 'Compactă' }],
+        transmission: { id: 3, name: 'Automată' },
+      },
+    ],
+  });
+
+  apiClientMock.getOffers.mockResolvedValue({ data: [] });
+
+  const activePeriod: Partial<WheelOfFortunePeriod> = {
+    id: 11,
+    name: 'Promotie vară',
+    start_at: '2025-01-01',
+    end_at: '2025-12-31',
+    active: true,
+    is_active: true,
+    active_months: [6, 7, 8],
+  };
+
+  apiClientMock.getWheelOfFortunePeriods.mockResolvedValue({ data: [activePeriod] });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('HeroSection', () => {
+  it('afișează câmpurile formularului și lansează căutarea cu valorile selectate', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<HeroSection />);
+
+    await waitForCarCategories();
+
+    const pickupInput = screen.getByLabelText(/Data ridicare/i) as HTMLInputElement;
+    const returnInput = screen.getByLabelText(/Data returnare/i) as HTMLInputElement;
+    const locationSelect = screen.getByLabelText(/Locația/i) as HTMLSelectElement;
+    const carTypeSelect = screen.getByLabelText(/Tip mașină/i) as HTMLSelectElement;
+
+    expect(pickupInput.value).not.toBe('');
+    expect(returnInput.value).not.toBe('');
+
+    await user.selectOptions(locationSelect, 'otopeni');
+    await user.selectOptions(carTypeSelect, '7');
+
+    await user.click(screen.getByRole('button', { name: /Caută mașini/i }));
+
+    await waitFor(() => expect(pushMock).toHaveBeenCalledTimes(1));
+    const destination = pushMock.mock.calls[0]?.[0] as string;
+    expect(destination).toContain('start_date=');
+    expect(destination).toContain('end_date=');
+    expect(destination).toContain('car_type=7');
+    expect(destination).toContain('location=otopeni');
+  });
+
+  it('sincronizează intervalul selectat în BookingContext', async () => {
+    const user = userEvent.setup();
+    const setBooking = vi.fn();
+    renderWithProviders(<HeroSection />, { setBooking });
+
+    await waitForCarCategories();
+
+    const pickupInput = screen.getByLabelText(/Data ridicare/i) as HTMLInputElement;
+    const returnInput = screen.getByLabelText(/Data returnare/i) as HTMLInputElement;
+
+    await user.clear(pickupInput);
+    await user.type(pickupInput, '2025-09-01T10:00');
+    await user.clear(returnInput);
+    await user.type(returnInput, '2025-09-04T09:30');
+
+    await waitFor(() =>
+      expect(setBooking).toHaveBeenCalledWith(
+        expect.objectContaining({ startDate: '2025-09-01T10:00', endDate: '2025-09-04T09:30' }),
+      ),
+    );
+  });
+});
+
+describe('FleetSection', () => {
+  it('încarcă flota recomandată și permite navigarea manuală', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<FleetSection />);
+
+    await waitForHomePageCars();
+
+    expect(screen.getAllByText('Dacia Logan').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Renault Clio').length).toBeGreaterThan(0);
+    expect(apiClientMock.getHomePageCars).toHaveBeenCalledWith({ limit: 4, language: 'ro' });
+
+    const carouselRegion = screen.getByRole('region', { name: /Carousel/i });
+    const resolveTrack = () => carouselRegion.querySelector('div.flex') as HTMLElement | null;
+
+    const currentTrack = resolveTrack();
+    expect(currentTrack).not.toBeNull();
+    expect(currentTrack?.style.transform).toBe('translateX(-0%)');
+
+    const nextButton = screen.getByRole('button', { name: /Mașina următoare/i });
+    await user.click(nextButton);
+
+    await waitFor(() => {
+      const updatedTrack = resolveTrack();
+      expect(updatedTrack?.style.transform).toBe('translateX(-100%)');
+    });
+
+    const previousButton = screen.getByRole('button', { name: /Mașina precedentă/i });
+    await user.click(previousButton);
+
+    await waitFor(() => {
+      const updatedTrack = resolveTrack();
+      expect(updatedTrack?.style.transform).toBe('translateX(-0%)');
+    });
+
+    const cta = screen.getByRole('link', { name: /Vezi toată flota/i });
+    expect(cta).toHaveAttribute('href', '/cars');
+  });
+});
+
+describe('ContactSection', () => {
+  it('afișează canalele de contact cu link-urile corecte', () => {
+    renderWithProviders(<ContactSection />);
+
+    expect(screen.getByRole('heading', { name: /Contactează-ne/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Sună la \+40 723 817 551/i })).toHaveAttribute(
+      'href',
+      'tel:+40723817551',
+    );
+    expect(screen.getByRole('link', { name: /Contactează pe WhatsApp/i })).toHaveAttribute(
+      'href',
+      'https://wa.me/40723817551',
+    );
+    expect(screen.getByRole('link', { name: /Trimite email/i })).toHaveAttribute(
+      'href',
+      'mailto:contact@dacars.ro',
+    );
+    expect(screen.getByTestId('lazy-map')).toBeInTheDocument();
+  });
+});
+
+describe('HomePageClient', () => {
+  it('deschide popup-ul roții norocului pentru rezervările eligibile și permite închiderea lui', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<HomePageClient />, {
+      booking: {
+        startDate: '2025-06-10T08:00',
+        endDate: '2025-06-15T10:00',
+      },
+    });
+
+    await waitForHomePageCars();
+
+    expect(screen.getByTestId('elfsight-widget')).toBeInTheDocument();
+    expect(apiClientMock.getWheelOfFortunePeriods).not.toHaveBeenCalled();
+
+    window.dispatchEvent(new CustomEvent('booking:dates-adjusted'));
+
+    await waitFor(() => expect(apiClientMock.getWheelOfFortunePeriods).toHaveBeenCalledTimes(1));
+
+    await waitFor(() => expect(screen.getByTestId('wheel-popup')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: /Închide roata/i }));
+
+    await waitFor(() => expect(screen.queryByTestId('wheel-popup')).not.toBeInTheDocument());
+  });
+});

--- a/components/__tests__/clientPublicFlowFull.test.tsx
+++ b/components/__tests__/clientPublicFlowFull.test.tsx
@@ -1,0 +1,640 @@
+import React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import HomePageClient from '@/components/home/HomePageClient';
+import CarsPageClient from '@/components/cars/CarsPageClient';
+import ReservationPage from '@/app/checkout/page';
+import { BookingContext, defaultBooking } from '@/context/booking-store';
+import { LocaleProvider } from '@/context/LocaleContext';
+import type { BookingData } from '@/types/booking';
+import type { StoredWheelPrizeEntry } from '@/lib/wheelStorage';
+
+type ApiClientMock = {
+  getCarCategories: ReturnType<typeof vi.fn>;
+  getHomePageCars: ReturnType<typeof vi.fn>;
+  getOffers: ReturnType<typeof vi.fn>;
+  getWheelOfFortunePeriods: ReturnType<typeof vi.fn>;
+  setLanguage: ReturnType<typeof vi.fn>;
+  getCarsByDateCriteria: ReturnType<typeof vi.fn>;
+  getServices: ReturnType<typeof vi.fn>;
+  checkCarAvailability: ReturnType<typeof vi.fn>;
+  getCarForBooking: ReturnType<typeof vi.fn>;
+  validateDiscountCode: ReturnType<typeof vi.fn>;
+  quotePrice: ReturnType<typeof vi.fn>;
+  createBooking: ReturnType<typeof vi.fn>;
+};
+
+function createApiClientMock(): ApiClientMock {
+  return {
+    getCarCategories: vi.fn(),
+    getHomePageCars: vi.fn(),
+    getOffers: vi.fn(),
+    getWheelOfFortunePeriods: vi.fn(),
+    setLanguage: vi.fn(),
+    getCarsByDateCriteria: vi.fn(),
+    getServices: vi.fn(),
+    checkCarAvailability: vi.fn(),
+    getCarForBooking: vi.fn(),
+    validateDiscountCode: vi.fn(),
+    quotePrice: vi.fn(),
+    createBooking: vi.fn(),
+  };
+}
+
+const apiClientMock = vi.hoisted(() => createApiClientMock());
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+let currentSearchParams = new URLSearchParams();
+let currentPathname = '/';
+
+vi.mock('next/navigation', () => {
+  return {
+    useRouter: () => ({
+      push: pushMock,
+      replace: replaceMock,
+    }),
+    useSearchParams: () => currentSearchParams,
+    usePathname: () => currentPathname,
+  };
+});
+
+vi.mock('@/lib/api', () => ({
+  __esModule: true,
+  apiClient: apiClientMock,
+  default: apiClientMock,
+}));
+
+vi.mock('@/components/ElfsightWidget', () => ({
+  __esModule: true,
+  default: () => <div data-testid="elfsight-widget">Widget</div>,
+}));
+
+vi.mock('@/components/WheelOfFortune', () => ({
+  __esModule: true,
+  default: ({ onClose }: { onClose?: () => void }) => (
+    <div data-testid="wheel-popup">
+      <p>Roata norocului disponibilă</p>
+      <button type="button" onClick={onClose}>
+        Închide roata
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/components/LazyMap', () => ({
+  __esModule: true,
+  default: () => <div data-testid="lazy-map">Harta</div>,
+}));
+
+vi.mock('@/components/checkout/SelectedCarGallery', () => ({
+  __esModule: true,
+  default: () => <div data-testid="selected-car-gallery">Galerie</div>,
+}));
+
+const wheelStorageMocks = vi.hoisted(() => {
+  const getStoredWheelPrizeMock = vi.fn<[], StoredWheelPrizeEntry | null>();
+  const clearStoredWheelPrizeMock = vi.fn();
+  const isStoredWheelPrizeActiveMock = vi.fn<[], boolean>();
+
+  return {
+    getStoredWheelPrizeMock,
+    clearStoredWheelPrizeMock,
+    isStoredWheelPrizeActiveMock,
+    module: {
+      __esModule: true,
+      getStoredWheelPrize: (
+        ...args: Parameters<typeof getStoredWheelPrizeMock>
+      ) => getStoredWheelPrizeMock(...args),
+      clearStoredWheelPrize: (
+        ...args: Parameters<typeof clearStoredWheelPrizeMock>
+      ) => clearStoredWheelPrizeMock(...args),
+      isStoredWheelPrizeActive: (
+        ...args: Parameters<typeof isStoredWheelPrizeActiveMock>
+      ) => isStoredWheelPrizeActiveMock(...args),
+    } satisfies Record<string, unknown>,
+  };
+});
+
+const {
+  getStoredWheelPrizeMock,
+  clearStoredWheelPrizeMock,
+  isStoredWheelPrizeActiveMock,
+} = wheelStorageMocks;
+
+vi.mock('@/lib/wheelStorage', () => wheelStorageMocks.module);
+
+const renderWithProviders = (
+  ui: React.ReactElement,
+  options: { booking?: Partial<BookingData> } = {},
+) => {
+  const initialBooking: BookingData = {
+    ...defaultBooking,
+    appliedOffers: [],
+    ...options.booking,
+  };
+  const setBookingSpy = vi.fn<(next: BookingData) => void>();
+
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [booking, setBooking] = React.useState<BookingData>(initialBooking);
+
+    const handleSetBooking = React.useCallback((next: BookingData) => {
+      setBooking(next);
+      setBookingSpy(next);
+    }, []);
+
+    return (
+      <LocaleProvider initialLocale="ro">
+        <BookingContext.Provider value={{ booking, setBooking: handleSetBooking }}>
+          {children}
+        </BookingContext.Provider>
+      </LocaleProvider>
+    );
+  };
+
+  const result = render(ui, { wrapper: Wrapper });
+
+  return { ...result, setBookingSpy };
+};
+
+const resetApiClientMock = () => {
+  (Object.values(apiClientMock) as Array<ReturnType<typeof vi.fn>>).forEach((mockFn) => {
+    mockFn.mockReset();
+  });
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+beforeEach(() => {
+  resetApiClientMock();
+  pushMock.mockReset();
+  replaceMock.mockReset();
+  currentSearchParams = new URLSearchParams();
+  currentPathname = '/';
+  getStoredWheelPrizeMock.mockReset();
+  clearStoredWheelPrizeMock.mockReset();
+  isStoredWheelPrizeActiveMock.mockReset();
+  window.localStorage.clear();
+});
+
+const buildWheelPrize = (): StoredWheelPrizeEntry => ({
+  version: 1,
+  prize: {
+    id: 9,
+    period_id: 3,
+    title: 'Reducere 15%',
+    description: 'Premiu test',
+    amount: 15,
+    color: '#34d399',
+    probability: 100,
+    type: 'percentage_discount',
+    created_at: null,
+    updated_at: null,
+  },
+  winner: {
+    name: 'Ion Pop',
+    phone: '+40722123456',
+  },
+  wheel_of_fortune_id: 4,
+  prize_id: 7,
+  saved_at: '2030-05-01T00:00:00Z',
+  expires_at: '2030-12-31T00:00:00Z',
+});
+
+describe('Fluxul complet al clienților DaCars', () => {
+  it('gestionează interacțiunile de pe homepage: formular, oferte și roata norocului', async () => {
+    const homeCar = {
+      id: 101,
+      name: 'Dacia Logan',
+      type: { id: 1, name: 'Sedan' },
+      transmission: { id: 2, name: 'Manuală' },
+      fuel: { id: 3, name: 'Benzină' },
+      number_of_seats: 5,
+      rental_rate: 55,
+      rental_rate_casco: 75,
+      days: 4,
+      deposit: 100,
+      total_deposit: 200,
+      total_without_deposit: 220,
+      image: '/images/test-car.jpg',
+      images: ['/images/test-car.jpg'],
+      avg_review: 4.7,
+      content: 'Autovehicul pentru testare',
+    };
+
+    apiClientMock.getCarCategories.mockResolvedValue({
+      data: [
+        { id: 7, name: 'SUV' },
+      ],
+    });
+    apiClientMock.getHomePageCars.mockResolvedValue({ data: [homeCar] });
+    apiClientMock.getOffers.mockResolvedValue({
+      data: [
+        {
+          id: 44,
+          title: 'Reducere 10%',
+          description: 'Oferta test',
+          discount_label: '-10%',
+          offer_type: 'percentage_discount',
+          offer_value: '10',
+          primary_cta_label: 'Aplică reducerea',
+          primary_cta_url: '/checkout',
+        },
+      ],
+    });
+    apiClientMock.getWheelOfFortunePeriods.mockResolvedValue({
+      data: [
+        {
+          id: 5,
+          name: 'Campanie primăvară',
+          starts_at: '2030-01-01',
+          ends_at: '2030-12-31',
+          active: true,
+          is_active: true,
+          active_months: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+        },
+      ],
+    });
+
+    const initialBooking: BookingData = {
+      ...defaultBooking,
+      startDate: '2030-06-01T10:00',
+      endDate: '2030-06-05T10:00',
+      appliedOffers: [],
+      withDeposit: false,
+      selectedCar: null,
+    };
+
+    const user = userEvent.setup();
+    const { setBookingSpy } = renderWithProviders(<HomePageClient />, {
+      booking: initialBooking,
+    });
+
+    await waitFor(() => expect(apiClientMock.setLanguage).toHaveBeenCalledWith('ro'));
+    await waitFor(() => expect(apiClientMock.getHomePageCars).toHaveBeenCalled());
+    await waitFor(() => expect(apiClientMock.getOffers).toHaveBeenCalled());
+
+    const pickupInput = screen.getByLabelText('Data ridicare');
+    const returnInput = screen.getByLabelText('Data returnare');
+    const locationSelect = screen.getByLabelText('Locația');
+    const carTypeSelect = screen.getByLabelText('Tip mașină');
+
+    await user.clear(pickupInput);
+    await user.type(pickupInput, '2030-06-10T10:30');
+    await user.clear(returnInput);
+    await user.type(returnInput, '2030-06-15T10:30');
+    await user.selectOptions(locationSelect, 'otopeni');
+    await user.selectOptions(carTypeSelect, '7');
+
+    await waitFor(() => {
+      expect(setBookingSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startDate: '2030-06-10T10:30',
+          endDate: '2030-06-15T10:30',
+        }),
+      );
+    });
+
+    await waitFor(() => expect(apiClientMock.getWheelOfFortunePeriods).toHaveBeenCalled());
+    const wheelPopup = await screen.findByTestId('wheel-popup');
+    expect(wheelPopup).toBeInTheDocument();
+    await user.click(within(wheelPopup).getByRole('button', { name: 'Închide roata' }));
+    await waitFor(() => expect(screen.queryByTestId('wheel-popup')).not.toBeInTheDocument());
+
+    const offerButton = await screen.findByRole('button', { name: 'Aplică reducerea' });
+    await user.click(offerButton);
+
+    await waitFor(() => {
+      expect(setBookingSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appliedOffers: [
+            expect.objectContaining({ id: 44, title: 'Reducere 10%' }),
+          ],
+        }),
+      );
+    });
+    expect(pushMock).toHaveBeenCalledWith('/checkout');
+
+    pushMock.mockClear();
+    await user.click(screen.getByRole('button', { name: 'Caută mașini' }));
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledTimes(1);
+      const target = pushMock.mock.calls[0][0] as string;
+      const url = new URL(target, 'https://dacars.ro');
+      expect(url.pathname).toBe('/cars');
+      expect(url.searchParams.get('start_date')).toBe('2030-06-10T10:30');
+      expect(url.searchParams.get('end_date')).toBe('2030-06-15T10:30');
+      expect(url.searchParams.get('car_type')).toBe('7');
+      expect(url.searchParams.get('location')).toBe('otopeni');
+    });
+  });
+
+  it('permite filtrarea flotei, rezervarea fără/cu garanție și sincronizarea parametrilor pe pagina /cars', async () => {
+    currentPathname = '/cars';
+    currentSearchParams = new URLSearchParams(
+      'start_date=2030-07-01T09:00&end_date=2030-07-05T09:00&sort_by=cheapest',
+    );
+    window.history.replaceState({}, '', `/cars?${currentSearchParams.toString()}`);
+
+    apiClientMock.getCarCategories.mockResolvedValue({ data: [{ id: 12, name: 'SUV' }] });
+    apiClientMock.getCarsByDateCriteria.mockResolvedValue({
+      data: [
+        {
+          id: 77,
+          name: 'VW Golf',
+          type: { id: 4, name: 'Hatchback' },
+          transmission: { id: 2, name: 'Manuală' },
+          fuel: { id: 1, name: 'Benzină' },
+          number_of_seats: 5,
+          rental_rate: 45,
+          rental_rate_casco: 55,
+          days: 4,
+          deposit: 150,
+          total_deposit: 260,
+          total_without_deposit: 220,
+          image: '/images/vw-golf.jpg',
+          images: ['/images/vw-golf.jpg'],
+          avg_review: 4.6,
+          content: 'Compactă ideală pentru oraș',
+        },
+      ],
+      meta: {
+        total: 1,
+        last_page: 1,
+      },
+    });
+
+    const initialBooking: BookingData = {
+      ...defaultBooking,
+      startDate: '2030-07-01T09:00',
+      endDate: '2030-07-05T09:00',
+      withDeposit: false,
+      appliedOffers: [],
+      selectedCar: null,
+    };
+
+    const user = userEvent.setup();
+    const { setBookingSpy } = renderWithProviders(<CarsPageClient />, {
+      booking: initialBooking,
+    });
+
+    await waitFor(() => expect(apiClientMock.getCarsByDateCriteria).toHaveBeenCalled());
+    expect(apiClientMock.getCarCategories).toHaveBeenCalledWith({ language: 'ro' });
+
+    const firstPayload = apiClientMock.getCarsByDateCriteria.mock.calls[0][0];
+    expect(firstPayload).toMatchObject({
+      start_date: '2030-07-01T09:00',
+      end_date: '2030-07-05T09:00',
+      sort_by: 'cheapest',
+    });
+
+    await screen.findByRole('heading', { name: 'VW Golf' });
+
+    const filtersToggle = screen.getByRole('button', { name: 'Comută filtrele' });
+    await user.click(filtersToggle);
+
+    const transmissionSelect = await screen.findByLabelText('Transmisie');
+    await user.selectOptions(transmissionSelect, '2');
+    await waitFor(() => {
+      const call = replaceMock.mock.calls.at(-1);
+      expect(call?.[0]).toContain('transmission=2');
+      expect(call?.[1]).toMatchObject({ scroll: false });
+    });
+
+    const searchInput = screen.getByPlaceholderText('Caută mașină...');
+    await user.type(searchInput, 'golf');
+    await waitFor(() => {
+      const call = replaceMock.mock.calls.at(-1);
+      expect(call?.[0]).toContain('search=golf');
+    });
+
+    const resetButtons = screen.getAllByRole('button', { name: 'Resetează filtrele' });
+    await user.click(resetButtons[0]);
+    await waitFor(() => {
+      const call = replaceMock.mock.calls.at(-1);
+      expect(call?.[0]).not.toContain('transmission=');
+      expect(call?.[0]).not.toContain('search=');
+    });
+
+    await user.click(screen.getByText('Rezervă fără garanție'));
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/checkout'));
+    await waitFor(() => {
+      const lastCall = setBookingSpy.mock.calls.at(-1)?.[0];
+      expect(lastCall?.withDeposit).toBe(false);
+      expect(lastCall?.selectedCar?.id).toBe(77);
+    });
+
+    pushMock.mockClear();
+    await user.click(screen.getByText('Rezervă cu garanție'));
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/checkout'));
+    await waitFor(() => {
+      const lastCall = setBookingSpy.mock.calls.at(-1)?.[0];
+      expect(lastCall?.withDeposit).toBe(true);
+      expect(lastCall?.selectedCar?.id).toBe(77);
+    });
+  });
+
+  it('parcurge formularul de checkout, validează coduri și trimite rezervarea completă', async () => {
+    currentPathname = '/checkout';
+    currentSearchParams = new URLSearchParams();
+    window.history.replaceState({}, '', '/checkout');
+
+    const storedPrize = buildWheelPrize();
+    getStoredWheelPrizeMock.mockReturnValue(storedPrize);
+    isStoredWheelPrizeActiveMock.mockReturnValue(true);
+
+    const apiCar = {
+      id: 501,
+      name: 'Dacia Logan',
+      type: { id: 10, name: 'Sedan' },
+      transmission: { id: 2, name: 'Manuală' },
+      fuel: { id: 1, name: 'Benzină' },
+      number_of_seats: 5,
+      rental_rate: 45,
+      rental_rate_casco: 55,
+      days: 4,
+      deposit: 200,
+      total_deposit: 320,
+      total_without_deposit: 260,
+      image: '/images/logan.jpg',
+      images: ['/images/logan.jpg'],
+      avg_review: 4.4,
+      content: 'Sedan de încredere',
+    };
+
+    apiClientMock.getServices.mockResolvedValue({
+      data: [
+        { id: 31, name: 'Asigurare completă', price: 25 },
+      ],
+    });
+    apiClientMock.checkCarAvailability.mockResolvedValue({ available: true });
+    apiClientMock.getCarForBooking.mockResolvedValue({ data: apiCar, available: true });
+    apiClientMock.validateDiscountCode.mockResolvedValue({
+      valid: true,
+      data: {
+        ...apiCar,
+        coupon: {
+          discount_deposit: '30',
+          discount_casco: '20',
+          discount_type: 'percent',
+        },
+      },
+    });
+    apiClientMock.quotePrice.mockResolvedValue({
+      price_per_day: 55,
+      base_price: 220,
+      sub_total: 260,
+      total: 245,
+      total_before_wheel_prize: 255,
+      total_services: 25,
+      offers_discount: 15,
+      coupon_amount: 20,
+      coupon_type: 'percent',
+      wheel_prize_discount: 10,
+      deposit_waived: false,
+      applied_offers: [
+        { id: 44, title: 'Reducere 10%', offer_type: 'percent', offer_value: '10', discount_label: '-10%' },
+      ],
+      wheel_prize: { eligible: true },
+    });
+    apiClientMock.createBooking.mockResolvedValue({ data: { booking_number: 'DAC123' } });
+
+    const selectedCar = {
+      id: apiCar.id,
+      name: apiCar.name,
+      type: apiCar.type.name,
+      typeId: apiCar.type.id,
+      image: '/images/logan.jpg',
+      gallery: ['/images/logan.jpg'],
+      price: 55,
+      rental_rate: String(apiCar.rental_rate),
+      rental_rate_casco: String(apiCar.rental_rate_casco),
+      days: apiCar.days,
+      deposit: apiCar.deposit,
+      total_deposit: apiCar.total_deposit,
+      total_without_deposit: apiCar.total_without_deposit,
+      available: true,
+      features: {
+        passengers: apiCar.number_of_seats,
+        transmission: apiCar.transmission.name,
+        transmissionId: apiCar.transmission.id,
+        fuel: apiCar.fuel.name,
+        fuelId: apiCar.fuel.id,
+        doors: 4,
+        luggage: 2,
+      },
+      rating: apiCar.avg_review,
+      description: apiCar.content,
+      specs: [],
+    };
+
+    const initialBooking: BookingData = {
+      ...defaultBooking,
+      startDate: '2030-08-01T10:00',
+      endDate: '2030-08-05T10:00',
+      withDeposit: false,
+      appliedOffers: [],
+      selectedCar,
+    };
+
+    const user = userEvent.setup();
+    const { setBookingSpy } = renderWithProviders(<ReservationPage />, {
+      booking: initialBooking,
+    });
+
+    await waitFor(() => expect(apiClientMock.getServices).toHaveBeenCalledWith({ language: 'ro' }));
+    await waitFor(() => expect(apiClientMock.getCarForBooking).toHaveBeenCalled());
+
+    const nameInput = await screen.findByLabelText('Nume *');
+    const emailInput = screen.getByLabelText('Email *');
+    const phoneInput = screen.getByLabelText(/Telefon/);
+    const flightInput = screen.getByLabelText('Zbor (opțional)');
+    const couponInput = screen.getByPlaceholderText('Ex: WHEEL10');
+
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Ion Pop');
+    await user.clear(emailInput);
+    await user.type(emailInput, 'ion.pop@example.com');
+    await user.clear(phoneInput);
+    await user.type(phoneInput, '722123123');
+    await user.type(flightInput, 'RO123');
+
+    const serviceCheckbox = await screen.findByLabelText('Asigurare completă - 25€');
+    await user.click(serviceCheckbox);
+
+    await waitFor(() => {
+      const call = apiClientMock.quotePrice.mock.calls.at(-1)?.[0];
+      expect(call?.service_ids).toEqual([31]);
+      expect(call?.total_services).toBe(25);
+    });
+
+    await user.clear(couponInput);
+    await user.type(couponInput, 'WHEEL10');
+    const validateButton = await screen.findByRole('button', { name: 'Validează codul' });
+    await user.click(validateButton);
+
+    await waitFor(() => expect(apiClientMock.validateDiscountCode).toHaveBeenCalled());
+    await waitFor(() => {
+      const call = apiClientMock.validateDiscountCode.mock.calls.at(-1)?.[0];
+      expect(call).toMatchObject({
+        code: 'WHEEL10',
+        car_id: 501,
+      });
+      expect(Number(call?.price)).toBe(45);
+      expect(Number(call?.price_casco)).toBe(55);
+    });
+
+    await waitFor(() => {
+      const call = apiClientMock.quotePrice.mock.calls.at(-1)?.[0];
+      expect(call?.coupon_code).toBe('WHEEL10');
+      expect(call?.wheel_prize_discount).toBeGreaterThan(0);
+    });
+
+    await user.click(screen.getByLabelText('Cu garanție'));
+    await waitFor(() => {
+      const lastCall = setBookingSpy.mock.calls.at(-1)?.[0];
+      expect(lastCall?.withDeposit).toBe(true);
+    });
+
+    const submitButton = screen.getByRole('button', { name: 'Finalizează rezervarea' });
+    await waitFor(() => expect(submitButton).toBeEnabled());
+    await user.click(submitButton);
+
+    await waitFor(() => expect(apiClientMock.createBooking).toHaveBeenCalled());
+    const bookingPayload = apiClientMock.createBooking.mock.calls[0][0];
+    expect(bookingPayload).toMatchObject({
+      customer_name: 'Ion Pop',
+      customer_email: 'ion.pop@example.com',
+      customer_phone: '+40722123123',
+      flight_number: 'RO123',
+      service_ids: [31],
+      coupon_code: 'WHEEL10',
+      wheel_prize_discount: 10,
+      wheel_prize: expect.objectContaining({ eligible: true }),
+      car_id: 501,
+    });
+
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/success'));
+    expect(clearStoredWheelPrizeMock).toHaveBeenCalled();
+
+    const storedReservation = window.localStorage.getItem('reservationData');
+    expect(storedReservation).toBeTruthy();
+  });
+});
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,9 @@
         "@mdx-js/loader": "^3.0.1",
         "@next/eslint-plugin-next": "^15.5.2",
         "@next/mdx": "^15.4.6",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.5.1",
         "@types/node": "^20.14.9",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
@@ -50,6 +53,13 @@
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.3.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -105,6 +115,22 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -2200,6 +2226,156 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
@@ -2209,6 +2385,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.2",
@@ -3830,6 +4014,13 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "dev": true,
@@ -4077,6 +4268,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -5592,6 +5791,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
@@ -6380,6 +6589,17 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -7239,6 +7459,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -8222,6 +8452,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -9031,6 +9275,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.1",
     "@next/eslint-plugin-next": "^15.5.2",
     "@next/mdx": "^15.4.6",
     "@mdx-js/loader": "^3.0.1",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,5 +12,6 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
   },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,41 @@
+import React from 'react';
+import '@testing-library/jest-dom/vitest';
+import { vi } from 'vitest';
+
+Object.defineProperty(globalThis, 'React', {
+  value: React,
+  writable: true,
+  configurable: true,
+});
+
+class IntersectionObserverMock {
+  readonly observe = vi.fn();
+  readonly unobserve = vi.fn();
+  readonly disconnect = vi.fn();
+  readonly takeRecords = vi.fn(() => [] as IntersectionObserverEntry[]);
+}
+
+Object.defineProperty(globalThis, 'IntersectionObserver', {
+  writable: true,
+  configurable: true,
+  value: IntersectionObserverMock,
+});
+
+if (typeof window !== 'undefined') {
+  if (!window.scrollTo) {
+    window.scrollTo = vi.fn();
+  }
+}
+
+vi.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    const { src, alt, ...rest } = props ?? {};
+    const resolvedSrc = typeof src === 'string' ? src : src?.src ?? '';
+    return React.createElement('img', {
+      alt,
+      ...rest,
+      src: resolvedSrc,
+    });
+  },
+}));


### PR DESCRIPTION
## Summary
- add a Vitest suite that covers the homepage search, offers, and wheel popup behaviour for client users
- expand the suite to exercise the cars listing filters, booking buttons, and URL synchronisation
- verify checkout form completion including services, coupons, wheel prize redemption, and booking submission payloads

## Testing
- npm run lint
- npx vitest run components/__tests__/clientPublicFlowFull.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e0f2cf3e888329b7c8821ad8474f9d