### PR TITLE
Add Mixpanel analytics initializer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,7 @@ import { buildMetadata } from "@/lib/seo/meta";
 import { siteMetadata } from "@/lib/seo/siteMetadata";
 import { GlobalStyles } from "./global-styles";
 import { AVAILABLE_LOCALES, LOCALE_STORAGE_KEY, DEFAULT_LOCALE } from "@/lib/i18n/config";
+import MixpanelInitializer from "@/components/analytics/MixpanelInitializer";
 
 
 const poppins = Poppins({
@@ -114,6 +115,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         />
       </head>
       <body className="min-h-screen bg-white">
+        <MixpanelInitializer />
         <Script id="prefill-locale" strategy="beforeInteractive">
           {`
             (function() {

--- a/components/analytics/MixpanelInitializer.tsx
+++ b/components/analytics/MixpanelInitializer.tsx
@@ -2,17 +2,24 @@
 
 import { useEffect } from "react";
 
-import { useAuth } from "@/context/AuthContext";
+import { useOptionalAuth } from "@/context/AuthContext";
 import { identifyMixpanelUser, initMixpanel } from "@/lib/mixpanelClient";
 
 const MixpanelInitializer = () => {
-  const { user } = useAuth();
+  const auth = useOptionalAuth();
+  const user = auth?.user ?? null;
 
   useEffect(() => {
     initMixpanel();
   }, []);
 
   useEffect(() => {
+    const distinctId = user?.id;
+
+    if (distinctId === undefined || distinctId === null) {
+      return;
+    }
+
     if (!user) {
       return;
     }
@@ -37,7 +44,7 @@ const MixpanelInitializer = () => {
 
     const mixpanelTraits = Object.keys(traits).length > 0 ? traits : undefined;
 
-    identifyMixpanelUser(String(user.id), mixpanelTraits);
+    identifyMixpanelUser(String(distinctId), mixpanelTraits);
   }, [user]);
 
   return null;

--- a/components/analytics/MixpanelInitializer.tsx
+++ b/components/analytics/MixpanelInitializer.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { useAuth } from "@/context/AuthContext";
+import { identifyMixpanelUser, initMixpanel } from "@/lib/mixpanelClient";
+
+const MixpanelInitializer = () => {
+  const { user } = useAuth();
+
+  useEffect(() => {
+    initMixpanel();
+  }, []);
+
+  useEffect(() => {
+    if (!user) {
+      return;
+    }
+
+    const traits: Record<string, unknown> = {};
+
+    if (user.email) {
+      traits.email = user.email;
+    }
+
+    if (user.username) {
+      traits.username = user.username;
+    }
+
+    if (user.first_name) {
+      traits.first_name = user.first_name;
+    }
+
+    if (user.last_name) {
+      traits.last_name = user.last_name;
+    }
+
+    const mixpanelTraits = Object.keys(traits).length > 0 ? traits : undefined;
+
+    identifyMixpanelUser(String(user.id), mixpanelTraits);
+  }, [user]);
+
+  return null;
+};
+
+export default MixpanelInitializer;

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -72,3 +72,5 @@ export const useAuth = () => {
   }
   return ctx;
 };
+
+export const useOptionalAuth = () => useContext(AuthContext);

--- a/lib/mixpanelClient.js
+++ b/lib/mixpanelClient.js
@@ -10,3 +10,55 @@ export const initMixpanel = () => {
 
     mixpanel.init(MIXPANEL_TOKEN, { autocapture: true });
 }
+
+/**
+ * Trim an object by removing entries with `null` or `undefined` values.
+ * @param {Record<string, unknown> | undefined} value
+ */
+const sanitizeProps = (value) => {
+    if (!value || typeof value !== 'object') {
+        return undefined;
+    }
+
+    const entries = Object.entries(value).filter(([, propValue]) => propValue !== null && propValue !== undefined);
+    if (entries.length === 0) {
+        return undefined;
+    }
+
+    return Object.fromEntries(entries);
+};
+
+/**
+ * @param {string} eventName
+ * @param {Record<string, unknown>} [props]
+ */
+export const trackMixpanelEvent = (eventName, props) => {
+    if (!MIXPANEL_TOKEN) {
+        return;
+    }
+
+    const sanitizedProps = sanitizeProps(props);
+    if (sanitizedProps) {
+        mixpanel.track(eventName, sanitizedProps);
+        return;
+    }
+
+    mixpanel.track(eventName);
+};
+
+/**
+ * @param {string} distinctId
+ * @param {Record<string, unknown>} [traits]
+ */
+export const identifyMixpanelUser = (distinctId, traits) => {
+    if (!MIXPANEL_TOKEN) {
+        return;
+    }
+
+    mixpanel.identify(distinctId);
+
+    const sanitizedTraits = sanitizeProps(traits);
+    if (sanitizedTraits) {
+        mixpanel.people.set(sanitizedTraits);
+    }
+};


### PR DESCRIPTION
## Summary
- add Mixpanel helper exports for tracking events and identifying users
- introduce a MixpanelInitializer client component that sets up analytics and links authenticated users
- mount the initializer in the root layout so analytics runs for every page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1fe98b88c8329a850239d85b0eb0e