### PR TITLE
Track landing view Mixpanel event

### DIFF
--- a/lib/mixpanel.ts
+++ b/lib/mixpanel.ts
@@ -1,0 +1,47 @@
+import mixpanel from "mixpanel-browser";
+
+const MIXPANEL_TOKEN = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN;
+
+let isMixpanelInitialized = false;
+
+const ensureMixpanelInitialized = () => {
+    if (!MIXPANEL_TOKEN) {
+        if (process.env.NODE_ENV !== "production") {
+            console.warn(
+                "Tokenul Mixpanel lipsește! Verifică variabila NEXT_PUBLIC_MIXPANEL_TOKEN.",
+            );
+        }
+        return false;
+    }
+
+    if (!isMixpanelInitialized) {
+        mixpanel.init(MIXPANEL_TOKEN, { autocapture: true });
+        isMixpanelInitialized = true;
+    }
+
+    return true;
+};
+
+export const trackMixpanelEvent = (
+    eventName: string,
+    properties?: Record<string, unknown>,
+) => {
+    if (typeof window === "undefined") {
+        return;
+    }
+
+    if (!ensureMixpanelInitialized()) {
+        return;
+    }
+
+    try {
+        mixpanel.track(eventName, properties);
+    } catch (error) {
+        if (process.env.NODE_ENV !== "production") {
+            console.error(
+                "Nu am putut trimite evenimentul Mixpanel",
+                error,
+            );
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- import the Mixpanel tracker in the home page client and fire a one-time landing_view event with booking context data
- add a Mixpanel helper that safely initialises the browser client before sending events

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1ff8065108329a4fa6850641795a2