### PR TITLE
Add Mixpanel tracking for checkout submission

### DIFF
--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -7,6 +7,7 @@ import {Label} from "@/components/ui/label";
 import PhoneInput from "@/components/PhoneInput";
 import {useBooking} from "@/context/useBooking";
 import { apiClient } from "@/lib/api";
+import { trackMixpanelEvent } from "@/lib/mixpanelClient";
 import { extractItem, extractList } from "@/lib/apiResponse";
 import { extractFirstCar } from "@/lib/adminBookingHelpers";
 import { describeWheelPrizeAmount } from "@/lib/wheelFormatting";
@@ -1496,6 +1497,11 @@ const ReservationPage = () => {
                 resolveReservationIdentifier(bookingRecord) ??
                 resolveReservationIdentifier(res) ??
                 `#${Math.floor(1000000 + Math.random() * 9000000)}`;
+            trackMixpanelEvent("checkout_submitted", {
+                ...payload,
+                reservationId,
+                quoteCouponType: payload.coupon_type ?? null,
+            });
             localStorage.setItem(
                 "reservationData",
                 JSON.stringify({

--- a/lib/mixpanelClient.js
+++ b/lib/mixpanelClient.js
@@ -10,3 +10,19 @@ export const initMixpanel = () => {
 
     mixpanel.init(MIXPANEL_TOKEN, { autocapture: true });
 }
+
+export const trackMixpanelEvent = (eventName, payload = {}) => {
+    if (!MIXPANEL_TOKEN) {
+        return;
+    }
+
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    try {
+        mixpanel.track(eventName, payload);
+    } catch (error) {
+        console.error('Failed to track Mixpanel event', error);
+    }
+};


### PR DESCRIPTION
## Summary
- add a Mixpanel tracking helper to safely emit events in the browser
- record checkout submission details before redirecting to the success page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2075b33948329a5617117c06605aa