### PR TITLE
Track Mixpanel fleet filter interactions

### DIFF
--- a/components/cars/CarsPageClient.tsx
+++ b/components/cars/CarsPageClient.tsx
@@ -16,6 +16,7 @@ import { siteMetadata } from "@/lib/seo/siteMetadata";
 import { useBooking } from "@/context/useBooking";
 import { ApiCar, Car, CarCategory, type CarSearchUiPayload } from "@/types/car";
 import { useTranslations } from "@/lib/i18n/useTranslations";
+import { trackMixpanelEvent } from "@/lib/mixpanelClient";
 
 const siteUrl = siteMetadata.siteUrl;
 const fleetPageUrl = `${siteUrl}/cars`;
@@ -394,8 +395,17 @@ const FleetPage = () => {
 
     const handleFilterChange = (key: string, value: string) => {
         setFilters(prev => ({ ...prev, [key]: value }));
+
+        const eventProps = {
+            filter_key: key,
+            filter_value: value,
+            current_page: currentPage,
+            total_cars: totalCars,
+        };
+
         setCurrentPage(1);
         hasMoreRef.current = true;
+        trackMixpanelEvent("fleet_filters_updated", eventProps);
     };
 
     const clearFilters = () => {
@@ -410,6 +420,12 @@ const FleetPage = () => {
         setSearchTerm("");
         setCurrentPage(1);
         hasMoreRef.current = true;
+        trackMixpanelEvent("fleet_filters_updated", {
+            filter_key: "reset",
+            filter_value: "all",
+            current_page: currentPage,
+            total_cars: totalCars,
+        });
     };
 
     const activeFilters = useMemo(() => {

--- a/lib/mixpanelClient.js
+++ b/lib/mixpanelClient.js
@@ -10,3 +10,21 @@ export const initMixpanel = () => {
 
     mixpanel.init(MIXPANEL_TOKEN, { autocapture: true });
 }
+
+export const trackMixpanelEvent = (eventName, properties = {}) => {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    if (!MIXPANEL_TOKEN) {
+        return;
+    }
+
+    try {
+        mixpanel.track(eventName, properties);
+    } catch (error) {
+        if (process.env.NODE_ENV !== 'production') {
+            console.error('Failed to track Mixpanel event', error);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Mixpanel tracking for fleet filter interactions on the cars listing page
- expose a reusable helper to safely send Mixpanel events from the client

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e207569054832982e910d03767cc17