### PR TITLE
Track hero search submissions in Mixpanel

### DIFF
--- a/lib/mixpanelClient.js
+++ b/lib/mixpanelClient.js
@@ -2,11 +2,53 @@ import mixpanel from 'mixpanel-browser';
 
 const MIXPANEL_TOKEN = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN;
 
+const isClient = () => typeof window !== 'undefined';
+
+let mixpanelInitialized = false;
+
+const ensureInitialized = () => {
+    if (!MIXPANEL_TOKEN || !isClient()) {
+        return false;
+    }
+
+    if (!mixpanelInitialized) {
+        mixpanel.init(MIXPANEL_TOKEN, { autocapture: true });
+        mixpanelInitialized = true;
+    }
+
+    return true;
+};
+
 export const initMixpanel = () => {
-    if (!MIXPANEL_TOKEN) {
-        console.warn('Mixpanel token is missing! Check your .env file.');
+    if (!isClient()) {
         return;
     }
 
-    mixpanel.init(MIXPANEL_TOKEN, { autocapture: true });
-}
+    if (!MIXPANEL_TOKEN) {
+        if (process.env.NODE_ENV !== 'production') {
+            console.warn('Mixpanel token is missing! Check your .env file.');
+        }
+        return;
+    }
+
+    ensureInitialized();
+};
+
+export const trackMixpanelEvent = (eventName, properties = {}) => {
+    if (!eventName || typeof eventName !== 'string') {
+        return;
+    }
+
+    const ready = ensureInitialized();
+    if (!ready) {
+        return;
+    }
+
+    try {
+        mixpanel.track(eventName, properties);
+    } catch (error) {
+        if (process.env.NODE_ENV !== 'production') {
+            console.error('Failed to send Mixpanel event', error);
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- import the Mixpanel tracker in the hero search component and send a `hero_search_submitted` event with normalized form and booking data
- extend the Mixpanel client helper to initialize the SDK safely on the client and expose a reusable `trackMixpanelEvent`

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e20754ef3c83298fa427e9cb4a4d62