### PR TITLE
Add Mixpanel tracking for car CTA clicks

### DIFF
--- a/lib/mixpanel.ts
+++ b/lib/mixpanel.ts
@@ -1,0 +1,40 @@
+import mixpanel from "mixpanel-browser";
+
+const MIXPANEL_TOKEN = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN;
+
+let isInitialized = false;
+let warnedMissingToken = false;
+
+const isBrowser = () => typeof window !== "undefined";
+
+const ensureMixpanel = (): boolean => {
+    if (!isBrowser()) {
+        return false;
+    }
+
+    if (!MIXPANEL_TOKEN) {
+        if (!warnedMissingToken && process.env.NODE_ENV !== "production") {
+            console.warn("Mixpanel token is missing! Check your .env file.");
+            warnedMissingToken = true;
+        }
+        return false;
+    }
+
+    if (!isInitialized) {
+        mixpanel.init(MIXPANEL_TOKEN, { autocapture: true });
+        isInitialized = true;
+    }
+
+    return true;
+};
+
+export const trackMixpanelEvent = (
+    eventName: string,
+    properties?: Record<string, unknown>,
+): void => {
+    if (!ensureMixpanel()) {
+        return;
+    }
+
+    mixpanel.track(eventName, properties);
+};


### PR DESCRIPTION
## Summary
- add a Mixpanel helper that safely initializes the browser client and exposes a tracker
- instrument the car booking handler to emit the `car_cta_clicked` event with normalized car metadata

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e207588fac8329955997bf3d8cd5c8