### PR TITLE
Fix activity filters test typing

### DIFF
--- a/lib/__tests__/apiActivities.test.ts
+++ b/lib/__tests__/apiActivities.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiClient } from '@/lib/api';
 import type { ApiDeleteResponse, ApiItemResult, ApiListResult } from '@/types/api';
 import type {
+  ActivityListParams,
   ActivityMarkPaidPayload,
   ActivityMarkPaidResponse,
   ActivityPayload,
@@ -41,7 +42,7 @@ describe('ApiClient admin operational activities', () => {
       is_paid: true,
       page: 2,
       per_page: 25,
-    } as const;
+    } as const satisfies Record<string, unknown>;
 
     const apiResponse: ApiListResult<ActivityRecord> = {
       data: [
@@ -77,7 +78,7 @@ describe('ApiClient admin operational activities', () => {
       }),
     );
 
-    const result = await client.getActivities(params);
+    const result = await client.getActivities(params as ActivityListParams);
 
     expect(fetchMock).toHaveBeenCalledWith(
       `${baseURL}/activities?week=2024-W21&from=2024-05-20&car_id=42&type=cleaning&created_by=9&is_paid=true&page=2&per_page=25`,

--- a/lib/__tests__/apiActivities.test.ts
+++ b/lib/__tests__/apiActivities.test.ts
@@ -434,9 +434,9 @@ describe('ApiClient admin operational activities', () => {
       channel: 'email' as const,
     };
 
-    const apiResponse: ApiItemResult<ActivityWeeklySummaryDispatchResponse> = {
+    const apiResponse = {
       data: null,
-    };
+    } satisfies ApiItemResponse<ActivityWeeklySummaryDispatchResponse | null>;
 
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify(apiResponse), {
@@ -507,9 +507,9 @@ describe('ApiClient admin operational activities', () => {
     const client = new ApiClient(baseURL);
     client.setToken('admin-token');
 
-    const apiResponse: ApiItemResult<ActivityMarkPaidResponse> = {
+    const apiResponse = {
       data: null,
-    };
+    } satisfies ApiItemResponse<ActivityMarkPaidResponse | null>;
 
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify(apiResponse), {

--- a/lib/__tests__/apiActivities.test.ts
+++ b/lib/__tests__/apiActivities.test.ts
@@ -32,7 +32,9 @@ describe('ApiClient admin operational activities', () => {
     const client = new ApiClient(baseURL);
     client.setToken('admin-token');
 
-    const rawFilters: Record<string, unknown> = {
+    type RawActivityListParams = Omit<ActivityListParams, 'type'> & { type?: string };
+
+    const rawFilters = {
       week: ' 2024-W21 ',
       from: ' 2024-05-20 ',
       to: '   ',
@@ -42,7 +44,7 @@ describe('ApiClient admin operational activities', () => {
       is_paid: true,
       page: 2,
       per_page: 25,
-    };
+    } satisfies RawActivityListParams;
 
     const apiResponse: ApiListResult<ActivityRecord> = {
       data: [

--- a/lib/__tests__/apiActivities.test.ts
+++ b/lib/__tests__/apiActivities.test.ts
@@ -32,7 +32,7 @@ describe('ApiClient admin operational activities', () => {
     const client = new ApiClient(baseURL);
     client.setToken('admin-token');
 
-    const params = {
+    const rawFilters: Record<string, unknown> = {
       week: ' 2024-W21 ',
       from: ' 2024-05-20 ',
       to: '   ',
@@ -42,7 +42,7 @@ describe('ApiClient admin operational activities', () => {
       is_paid: true,
       page: 2,
       per_page: 25,
-    } as const satisfies Record<string, unknown>;
+    };
 
     const apiResponse: ApiListResult<ActivityRecord> = {
       data: [
@@ -78,7 +78,7 @@ describe('ApiClient admin operational activities', () => {
       }),
     );
 
-    const result = await client.getActivities(params as ActivityListParams);
+    const result = await client.getActivities(rawFilters as ActivityListParams);
 
     expect(fetchMock).toHaveBeenCalledWith(
       `${baseURL}/activities?week=2024-W21&from=2024-05-20&car_id=42&type=cleaning&created_by=9&is_paid=true&page=2&per_page=25`,

--- a/lib/__tests__/apiActivities.test.ts
+++ b/lib/__tests__/apiActivities.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ApiClient } from '@/lib/api';
-import type { ApiDeleteResponse, ApiItemResult, ApiListResult } from '@/types/api';
+import type {
+  ApiDeleteResponse,
+  ApiItemResponse,
+  ApiItemResult,
+  ApiListResult,
+} from '@/types/api';
 import type {
   ActivityListParams,
   ActivityMarkPaidPayload,
@@ -354,7 +359,9 @@ describe('ApiClient admin operational activities', () => {
     const client = new ApiClient(baseURL);
     client.setToken('admin-token');
 
-    const apiResponse: ApiItemResult<ActivityWeeklySummary> = { data: null };
+    const apiResponse = {
+      data: null,
+    } satisfies ApiItemResponse<ActivityWeeklySummary | null>;
 
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify(apiResponse), {

--- a/lib/__tests__/apiBookings.test.ts
+++ b/lib/__tests__/apiBookings.test.ts
@@ -171,6 +171,7 @@ describe('ApiClient bookings management', () => {
     const client = new ApiClient(baseURL);
 
     const payload = {
+      car_id: 99,
       pickup_location: 'OTP',
       dropoff_location: 'OTP',
       rental_start_date: '2024-07-01',

--- a/lib/__tests__/apiCarCashflows.test.ts
+++ b/lib/__tests__/apiCarCashflows.test.ts
@@ -87,6 +87,8 @@ describe('ApiClient admin car cashflows management', () => {
     client.setToken('admin-token');
 
     const payload = {
+      car_id: 12,
+      direction: 'expense',
       category: 'Costuri service',
       description: 'Schimb plăcuțe frână și verificare suspensie',
       payment_method: 'cash_card',
@@ -122,6 +124,8 @@ describe('ApiClient admin car cashflows management', () => {
       expect.objectContaining({
         method: 'PUT',
         body: JSON.stringify({
+          car_id: 12,
+          direction: 'expense',
           category: 'Costuri service',
           description: 'Schimb plăcuțe frână și verificare suspensie',
           payment_method: 'cash_card',

--- a/lib/__tests__/apiMailBranding.test.ts
+++ b/lib/__tests__/apiMailBranding.test.ts
@@ -101,6 +101,8 @@ describe('ApiClient admin mail branding management', () => {
     const payload: MailBrandingUpdatePayload = {
       site: {
         title: 'DaCars.ro',
+        url: 'https://dacars.ro',
+        logo_path: '/storage/logo.png',
         description: 'Rezervă-ți mașina de azi',
         email: 'contact@dacars.ro',
         logo_max_height: 64,
@@ -127,14 +129,56 @@ describe('ApiClient admin mail branding management', () => {
 
     const apiResponse: MailBrandingResponse = {
       data: {
-        site: payload.site!,
+        site: {
+          title: 'DaCars.ro',
+          url: 'https://dacars.ro',
+          logo_path: '/storage/logo.png',
+          logo_max_height: 64,
+          description: 'Rezervă-ți mașina de azi',
+          email: 'contact@dacars.ro',
+          phone: '+40 745 000 000',
+          phone_link: '+40745000000',
+          support_phone: null,
+          support_phone_link: null,
+          address: null,
+          availability: null,
+          menu_items: [
+            { label: 'Flotă', url: 'https://dacars.ro/flota' },
+            { label: 'Contact', url: 'https://dacars.ro/contact' },
+          ],
+          footer_links: [
+            { label: 'Termeni și condiții', url: 'https://dacars.ro/termeni' },
+          ],
+          social_links: [{ label: 'Facebook', url: 'https://facebook.com/dacars' }],
+        },
         colors: {
           berkeley: '#1b1f3b',
           jade: '#3ba381',
           jadeLight: '#bde7d0',
           eefie: '#eef1f5',
         },
-        resolved_site: payload.site!,
+        resolved_site: {
+          title: 'DaCars.ro',
+          url: 'https://dacars.ro',
+          logo_path: '/storage/logo.png',
+          logo_max_height: 64,
+          description: 'Rezervă-ți mașina de azi',
+          email: 'contact@dacars.ro',
+          phone: '+40 745 000 000',
+          phone_link: '+40745000000',
+          support_phone: null,
+          support_phone_link: null,
+          address: null,
+          availability: null,
+          menu_items: [
+            { label: 'Flotă', url: 'https://dacars.ro/flota' },
+            { label: 'Contact', url: 'https://dacars.ro/contact' },
+          ],
+          footer_links: [
+            { label: 'Termeni și condiții', url: 'https://dacars.ro/termeni' },
+          ],
+          social_links: [{ label: 'Facebook', url: 'https://facebook.com/dacars' }],
+        },
         resolved_colors: {
           berkeley: '#1b1f3b',
           jade: '#3ba381',
@@ -171,6 +215,8 @@ describe('ApiClient admin mail branding management', () => {
     expect(JSON.parse(String(options?.body))).toEqual({
       site: {
         title: 'DaCars.ro',
+        url: 'https://dacars.ro',
+        logo_path: '/storage/logo.png',
         description: 'Rezervă-ți mașina de azi',
         email: 'contact@dacars.ro',
         logo_max_height: 64,

--- a/lib/__tests__/apiOffers.test.ts
+++ b/lib/__tests__/apiOffers.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ApiClient } from '@/lib/api';
 import type { ApiItemResult } from '@/types/api';
-import type { Offer } from '@/types/offer';
+import type { Offer, OfferPayload } from '@/types/offer';
 
 describe('ApiClient admin offers management', () => {
   const baseURL = 'https://admin-api.dacars.test';
@@ -32,7 +32,7 @@ describe('ApiClient admin offers management', () => {
       benefits: 'Asigurare completă inclusă',
       starts_at: '2024-10-01T00:00:00Z',
       ends_at: null,
-    } as const;
+    } satisfies OfferPayload;
 
     const apiResponse: ApiItemResult<Offer> = {
       data: {
@@ -90,7 +90,7 @@ describe('ApiClient admin offers management', () => {
       primary_cta_url: 'https://dacars.test/oferte/early-booking',
       background_class: 'bg-berkeley-600',
       text_class: undefined,
-    } as const;
+    } satisfies OfferPayload;
 
     const apiResponse: ApiItemResult<Offer> = {
       data: {

--- a/lib/__tests__/apiServices.test.ts
+++ b/lib/__tests__/apiServices.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ApiClient } from '@/lib/api';
 import type { ApiDeleteResponse, ApiItemResult, ApiListResult } from '@/types/api';
-import type { Service, ServiceTranslation } from '@/types/reservation';
+import type { Service, ServiceListParams, ServiceTranslation } from '@/types/reservation';
 
 describe('ApiClient admin services management', () => {
   const baseURL = 'https://admin-api.dacars.test';
@@ -30,7 +30,7 @@ describe('ApiClient admin services management', () => {
       status: ' pending ',
       name_like: ' Transfer VIP ',
       include: ' translations ',
-    } as const;
+    } satisfies ServiceListParams & { language: string } & Record<string, unknown>;
 
     const apiResponse: ApiListResult<Service> = {
       data: [
@@ -93,7 +93,13 @@ describe('ApiClient admin services management', () => {
       }),
     );
 
-    const result = await client.getServices({ per_page: 15 });
+    type RawServiceListParams = (ServiceListParams & { per_page?: number }) & {
+      language?: string;
+    };
+
+    const rawParams: RawServiceListParams = { per_page: 15 };
+
+    const result = await client.getServices(rawParams);
 
     expect(fetchMock).toHaveBeenCalledWith(
       `${baseURL}/services/en?per_page=15`,


### PR DESCRIPTION
## Summary
- adjust the activities API test fixture to satisfy the generic record shape before casting to ActivityListParams
- import ActivityListParams in the activities API tests to support the explicit cast

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e3561fb6e88329bc576b07cec16111