### PR TITLE
Sanitize Mixpanel event payloads before tracking

### DIFF
--- a/lib/mixpanelClient.ts
+++ b/lib/mixpanelClient.ts
@@ -4,6 +4,119 @@ const MIXPANEL_TOKEN = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN;
 
 let isInitialized = false;
 
+const sanitizeMixpanelValue = (value: unknown): unknown => {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    if (value instanceof Date) {
+        return value.toISOString();
+    }
+
+    if (Array.isArray(value)) {
+        const sanitizedArray = value
+            .map((item) => sanitizeMixpanelValue(item))
+            .filter((item): item is Exclude<unknown, undefined> => item !== undefined);
+
+        return sanitizedArray;
+    }
+
+    if (value !== null && typeof value === "object") {
+        const entries = Object.entries(value as Record<string, unknown>)
+            .map(([key, nested]) => {
+                const sanitizedNested = sanitizeMixpanelValue(nested);
+
+                if (sanitizedNested === undefined) {
+                    return null;
+                }
+
+                if (
+                    typeof sanitizedNested === "object" &&
+                    sanitizedNested !== null &&
+                    !Array.isArray(sanitizedNested) &&
+                    Object.keys(sanitizedNested).length === 0
+                ) {
+                    return null;
+                }
+
+                if (Array.isArray(sanitizedNested) && sanitizedNested.length === 0) {
+                    return [key, []];
+                }
+
+                return [key, sanitizedNested];
+            })
+            .filter((entry): entry is [string, unknown] => entry !== null);
+
+        if (entries.length === 0) {
+            return undefined;
+        }
+
+        return Object.fromEntries(entries);
+    }
+
+    if (typeof value === "number") {
+        if (Number.isFinite(value)) {
+            return value;
+        }
+
+        return null;
+    }
+
+    if (
+        typeof value === "string" ||
+        typeof value === "boolean" ||
+        value === null
+    ) {
+        return value;
+    }
+
+    if (typeof value === "bigint") {
+        const asNumber = Number(value);
+        return Number.isFinite(asNumber) ? asNumber : value.toString();
+    }
+
+    if (typeof value === "symbol") {
+        return value.toString();
+    }
+
+    if (typeof value === "function") {
+        return undefined;
+    }
+
+    try {
+        return String(value);
+    } catch {
+        return undefined;
+    }
+};
+
+const sanitizeMixpanelProperties = (
+    payload: Record<string, unknown>,
+): Record<string, unknown> => {
+    const sanitizedEntries: Array<[string, unknown]> = [];
+
+    Object.entries(payload).forEach(([key, rawValue]) => {
+        const sanitizedValue = sanitizeMixpanelValue(rawValue);
+
+        if (sanitizedValue === undefined) {
+            return;
+        }
+
+        if (
+            typeof sanitizedValue === "object" &&
+            sanitizedValue !== null &&
+            !Array.isArray(sanitizedValue) &&
+            Object.keys(sanitizedValue).length === 0
+        ) {
+            return;
+        }
+
+        sanitizedEntries.push([key, sanitizedValue]);
+    });
+
+    return Object.fromEntries(sanitizedEntries);
+};
+
 const canUseMixpanel = () => {
     if (typeof window === "undefined") {
         return false;
@@ -39,7 +152,15 @@ export const trackMixpanelEvent = (
     }
 
     try {
-        mixpanel.track(eventName, payload);
+        const trimmedEventName = eventName.trim();
+
+        if (trimmedEventName.length === 0) {
+            return;
+        }
+
+        const sanitizedPayload = sanitizeMixpanelProperties(payload);
+
+        mixpanel.track(trimmedEventName, sanitizedPayload);
     } catch (error) {
         if (process.env.NODE_ENV !== "production") {
             console.error("Failed to track Mixpanel event", error);
@@ -64,7 +185,11 @@ export const identifyMixpanelUser = (
         mixpanel.identify(trimmedId);
 
         if (traits && Object.keys(traits).length > 0) {
-            mixpanel.people.set(traits);
+            const sanitizedTraits = sanitizeMixpanelProperties(traits);
+
+            if (Object.keys(sanitizedTraits).length > 0) {
+                mixpanel.people.set(sanitizedTraits);
+            }
         }
     } catch (error) {
         if (process.env.NODE_ENV !== "production") {

--- a/lib/mixpanelClient.ts
+++ b/lib/mixpanelClient.ts
@@ -22,30 +22,32 @@ const sanitizeMixpanelValue = (value: unknown): unknown => {
     }
 
     if (value !== null && typeof value === "object") {
-        const entries = Object.entries(value as Record<string, unknown>)
-            .map(([key, nested]) => {
-                const sanitizedNested = sanitizeMixpanelValue(nested);
+        const entries = Object.entries(value as Record<string, unknown>).reduce<
+            Array<[string, unknown]>
+        >((acc, [key, nested]) => {
+            const sanitizedNested = sanitizeMixpanelValue(nested);
 
-                if (sanitizedNested === undefined) {
-                    return null;
-                }
+            if (sanitizedNested === undefined) {
+                return acc;
+            }
 
-                if (
-                    typeof sanitizedNested === "object" &&
-                    sanitizedNested !== null &&
-                    !Array.isArray(sanitizedNested) &&
-                    Object.keys(sanitizedNested).length === 0
-                ) {
-                    return null;
-                }
+            if (
+                typeof sanitizedNested === "object" &&
+                sanitizedNested !== null &&
+                !Array.isArray(sanitizedNested) &&
+                Object.keys(sanitizedNested).length === 0
+            ) {
+                return acc;
+            }
 
-                if (Array.isArray(sanitizedNested) && sanitizedNested.length === 0) {
-                    return [key, []];
-                }
+            if (Array.isArray(sanitizedNested) && sanitizedNested.length === 0) {
+                acc.push([key, []]);
+                return acc;
+            }
 
-                return [key, sanitizedNested];
-            })
-            .filter((entry): entry is [string, unknown] => entry !== null);
+            acc.push([key, sanitizedNested]);
+            return acc;
+        }, []);
 
         if (entries.length === 0) {
             return undefined;


### PR DESCRIPTION
## Summary
- sanitize Mixpanel event payloads to strip unsupported values and normalise dates, arrays and nested objects
- guard against empty event names before tracking
- reuse the sanitisation pipeline when setting Mixpanel people traits

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e35ec485b883299c7fe0fd3006ee46