### PR TITLE
Add Mixpanel debug logging utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Aplicația presupune un backend Laravel ce expune API-uri REST securizate.
 | `IMAGE_PROXY_ALLOWLIST` | (Opțional) listă suplimentară de host-uri, separată prin virgulă, acceptate de API-ul de proxy pentru imagini. | – |
 | `CUSTOM_KEY` | Cheie opțională pentru logica custom din `next.config.js`. | – |
 | `ANALYZE` | Activează bundle analyzer (setare Next.js). | – |
+| `NEXT_PUBLIC_MIXPANEL_DEBUG` | Controlează logging-ul de debugging pentru evenimentele Mixpanel. Setează `true` pentru a vedea în consolă toate evenimentele, `false` pentru a dezactiva log-urile chiar și în dezvoltare. | – (implicit activ în dezvoltare) |
 
 Tokenul de autentificare este setat prin `apiClient.setToken` după login și salvat în `localStorage` sub `auth_token`. Toate request-urile includ antetul `X-API-KEY`, iar metodele standard `getCars`, `getBookings`, `getServices`, `getWheelPrizes` mapează răspunsurile la structurile TypeScript definite în `types/`.
 


### PR DESCRIPTION
## Summary
- add configurable Mixpanel debug logging for Mixpanel initialization, tracking and identification flows
- surface detailed console logs when events are ignored or fail to send to help diagnose missing analytics data
- document the NEXT_PUBLIC_MIXPANEL_DEBUG environment variable in the setup guide

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e363216554832999bb0528e08eca7d