### PR TITLE
Add Meta Pixel tracking and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Aplicația presupune un backend Laravel ce expune API-uri REST securizate.
 | `ANALYZE` | Activează bundle analyzer (setare Next.js). | – |
 | `NEXT_PUBLIC_MIXPANEL_DEBUG` | Controlează logging-ul de debugging pentru evenimentele Mixpanel. Setează `true` pentru a vedea în consolă toate evenimentele, `false` pentru a dezactiva log-urile chiar și în dezvoltare. | – (implicit activ în dezvoltare) |
 | `NEXT_PUBLIC_TIKTOK_PIXEL_ID` | ID-ul pixelului TikTok folosit pentru evenimentele de marketing descrise în `docs/tiktok-pixel.md`. | – |
+| `NEXT_PUBLIC_META_PIXEL_ID` | ID-ul Meta Pixel (Facebook) folosit pentru evenimentele descrise în `docs/meta-pixel.md`. | – |
 
 Tokenul de autentificare este setat prin `apiClient.setToken` după login și salvat în `localStorage` sub `auth_token`. Toate request-urile includ antetul `X-API-KEY`, iar metodele standard `getCars`, `getBookings`, `getServices`, `getWheelPrizes` mapează răspunsurile la structurile TypeScript definite în `types/`.
 
@@ -129,7 +130,7 @@ Tokenul de autentificare este setat prin `apiClient.setToken` după login și sa
 - **API layer**: adăugați metode noi în `lib/api.ts` și exportați tipuri în `types/` pentru a păstra contractul clar între frontend și backend.
 
 ## Extensibilitate și următori pași
-- **Monitorizare și analytics**: integrați servicii suplimentare în `app/layout.tsx` sau `components/PageTransition.tsx` pentru tracking al conversiilor; vezi și `docs/tiktok-pixel.md` pentru integrarea curentă TikTok.
+- **Monitorizare și analytics**: integrați servicii suplimentare în `app/layout.tsx` sau `components/PageTransition.tsx` pentru tracking al conversiilor; vezi și `docs/tiktok-pixel.md` respectiv `docs/meta-pixel.md` pentru integrările existente.
 - **Raportări avansate**: reutilizați `DataTable` și `Popup` pentru a construi rapoarte custom (ex. utilizare flotă pe luni).
 - **Automatizări marketing**: extindeți editorul de template-uri cu validări suplimentare și preview-uri pentru alte rezoluții folosind componentele existente din `mail-branding`.
 - **Internaționalizare**: proiectul include alias `@/locales/*` în `tsconfig.json`, pregătit pentru adăugarea de mesaje și traduceri viitoare.

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -9,6 +9,7 @@ import {useBooking} from "@/context/useBooking";
 import { apiClient } from "@/lib/api";
 import { trackMixpanelEvent } from "@/lib/mixpanelClient";
 import { trackTikTokEvent, TIKTOK_EVENTS } from "@/lib/tiktokPixel";
+import { trackMetaPixelEvent, META_PIXEL_EVENTS } from "@/lib/metaPixel";
 import { extractItem, extractList } from "@/lib/apiResponse";
 import { extractFirstCar } from "@/lib/adminBookingHelpers";
 import { describeWheelPrizeAmount } from "@/lib/wheelFormatting";
@@ -1003,6 +1004,27 @@ const ReservationPage = () => {
             applied_offer_ids: appliedOfferIds,
         });
 
+        trackMetaPixelEvent(META_PIXEL_EVENTS.INITIATE_CHECKOUT, {
+            value: Number.isFinite(estimatedCheckoutValue) ? estimatedCheckoutValue : undefined,
+            currency: DEFAULT_CURRENCY,
+            content_ids: [String(selectedCar.id)],
+            content_name: selectedCar.name,
+            content_type: "car",
+            contents: [
+                {
+                    id: String(selectedCar.id),
+                    quantity: 1,
+                    item_price: Number.isFinite(estimatedCheckoutValue) ? estimatedCheckoutValue : undefined,
+                    title: selectedCar.name,
+                },
+            ],
+            start_date: booking.startDate || undefined,
+            end_date: booking.endDate || undefined,
+            with_deposit: typeof booking.withDeposit === "boolean" ? booking.withDeposit : undefined,
+            service_ids: serviceIds,
+            applied_offer_ids: appliedOfferIds,
+        });
+
         checkoutLoadedTrackedRef.current = true;
     }, [
         appliedOffersSummary,
@@ -1582,6 +1604,28 @@ const ReservationPage = () => {
                     price: totalAfterAdjustments,
                 },
             ],
+            service_ids: serviceIds,
+            applied_offer_ids: appliedOffersPayload.map((offer) => offer.id),
+        });
+
+        trackMetaPixelEvent(META_PIXEL_EVENTS.LEAD, {
+            form_name: "checkout_reservation",
+            value: totalAfterAdjustments,
+            currency: DEFAULT_CURRENCY,
+            content_ids: [String(selectedCar.id)],
+            content_name: selectedCar.name,
+            content_type: "car",
+            contents: [
+                {
+                    id: String(selectedCar.id),
+                    quantity: 1,
+                    item_price: totalAfterAdjustments,
+                    title: selectedCar.name,
+                },
+            ],
+            with_deposit: typeof booking.withDeposit === "boolean" ? booking.withDeposit : undefined,
+            start_date: booking.startDate || undefined,
+            end_date: booking.endDate || undefined,
             service_ids: serviceIds,
             applied_offer_ids: appliedOffersPayload.map((offer) => offer.id),
         });

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,8 @@ import { AVAILABLE_LOCALES, LOCALE_STORAGE_KEY, DEFAULT_LOCALE } from "@/lib/i18
 import MixpanelInitializer from "../components/MixpanelInitializer";
 import TikTokPixelScript from "../components/TikTokPixelScript";
 import TikTokPixelInitializer from "../components/TikTokPixelInitializer";
+import MetaPixelScript from "../components/MetaPixelScript";
+import MetaPixelInitializer from "../components/MetaPixelInitializer";
 
 
 const poppins = Poppins({
@@ -83,6 +85,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <head>
         <GlobalStyles />
         <TikTokPixelScript />
+        <MetaPixelScript />
         <link
           rel="preload"
           as="image"
@@ -122,6 +125,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <Suspense fallback={null}>
           <MixpanelInitializer />
           <TikTokPixelInitializer />
+          <MetaPixelInitializer />
         </Suspense>
         <Script id="prefill-locale" strategy="beforeInteractive">
           {`

--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -8,6 +8,7 @@ import type { ReservationPayload } from "@/types/reservation";
 import type { WheelPrize } from "@/types/wheel";
 import { formatWheelPrizeExpiry } from "@/lib/wheelFormatting";
 import { trackTikTokEvent, TIKTOK_EVENTS } from "@/lib/tiktokPixel";
+import { trackMetaPixelEvent, META_PIXEL_EVENTS } from "@/lib/metaPixel";
 import { useTranslations } from "@/lib/i18n/useTranslations";
 import type { Locale } from "@/lib/i18n/config";
 import successMessagesRo from "@/messages/success/ro.json";
@@ -143,6 +144,36 @@ const SuccessPage = () => {
                     content_name: carName ?? undefined,
                     quantity: 1,
                     price: totalAmount ?? undefined,
+                },
+            ],
+            reservation_id:
+                typeof reservationData.reservationId === "string" && reservationData.reservationId.trim().length > 0
+                    ? reservationData.reservationId
+                    : undefined,
+            start_date: reservationData.rental_start_date || undefined,
+            end_date: reservationData.rental_end_date || undefined,
+            with_deposit:
+                typeof reservationData.with_deposit === "boolean"
+                    ? reservationData.with_deposit
+                    : undefined,
+            service_ids: normalizedServices,
+        });
+
+        const carIdString =
+            carId !== undefined && carId !== null ? String(carId) : undefined;
+
+        trackMetaPixelEvent(META_PIXEL_EVENTS.PURCHASE, {
+            value: totalAmount ?? undefined,
+            currency: DEFAULT_CURRENCY,
+            content_ids: carIdString ? [carIdString] : undefined,
+            content_name: carName,
+            content_type: "car",
+            contents: [
+                {
+                    id: carIdString,
+                    quantity: 1,
+                    item_price: totalAmount ?? undefined,
+                    title: carName,
                 },
             ],
             reservation_id:

--- a/components/ContactSection.tsx
+++ b/components/ContactSection.tsx
@@ -5,6 +5,7 @@ import { Phone, Mail, MapPin, Clock, MessageCircle } from "lucide-react";
 import LazyMap from "./LazyMap";
 import { useTranslations } from "@/lib/i18n/useTranslations";
 import { trackTikTokEvent, TIKTOK_EVENTS } from "@/lib/tiktokPixel";
+import { trackMetaPixelEvent, META_PIXEL_EVENTS } from "@/lib/metaPixel";
 
 type ContactMessages = {
     title?: { main?: string; highlight?: string };
@@ -67,12 +68,16 @@ const ContactSection = () => {
                                     href={phoneHref}
                                     className="text-jade font-dm-sans font-semibold hover:text-jade/80 transition-colors duration-300"
                                     aria-label={contact.items?.phone?.aria ?? `Sună la ${phoneNumber}`}
-                                    onClick={() =>
+                                    onClick={() => {
                                         trackTikTokEvent(TIKTOK_EVENTS.CONTACT, {
                                             contact_method: "phone",
                                             value: phoneNumber,
-                                        })
-                                    }
+                                        });
+                                        trackMetaPixelEvent(META_PIXEL_EVENTS.CONTACT, {
+                                            contact_method: "phone",
+                                            value: phoneNumber,
+                                        });
+                                    }}
                                 >
                                     {phoneNumber}
                                 </a>
@@ -93,12 +98,16 @@ const ContactSection = () => {
                                     href={whatsappHref}
                                     className="text-jade font-dm-sans font-semibold hover:text-jade/80 transition-colors duration-300"
                                     aria-label={contact.items?.whatsapp?.aria ?? `Contactează pe WhatsApp la ${phoneNumber}`}
-                                    onClick={() =>
+                                    onClick={() => {
                                         trackTikTokEvent(TIKTOK_EVENTS.CONTACT, {
                                             contact_method: "whatsapp",
                                             value: phoneNumber,
-                                        })
-                                    }
+                                        });
+                                        trackMetaPixelEvent(META_PIXEL_EVENTS.CONTACT, {
+                                            contact_method: "whatsapp",
+                                            value: phoneNumber,
+                                        });
+                                    }}
                                 >
                                     {phoneNumber}
                                 </a>
@@ -119,12 +128,16 @@ const ContactSection = () => {
                                     href={`mailto:${emailAddress}`}
                                     className="text-jade font-dm-sans font-semibold hover:text-jade/80 transition-colors duration-300"
                                     aria-label={contact.items?.email?.aria ?? `Trimite email la ${emailAddress}`}
-                                    onClick={() =>
+                                    onClick={() => {
                                         trackTikTokEvent(TIKTOK_EVENTS.CONTACT, {
                                             contact_method: "email",
                                             value: emailAddress,
-                                        })
-                                    }
+                                        });
+                                        trackMetaPixelEvent(META_PIXEL_EVENTS.CONTACT, {
+                                            contact_method: "email",
+                                            value: emailAddress,
+                                        });
+                                    }}
                                 >
                                     {emailAddress}
                                 </a>

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -25,6 +25,7 @@ import type { ApiListResult } from "@/types/api";
 import { useTranslations } from "@/lib/i18n/useTranslations";
 import { trackMixpanelEvent } from "@/lib/mixpanelClient";
 import { trackTikTokEvent, TIKTOK_EVENTS } from "@/lib/tiktokPixel";
+import { trackMetaPixelEvent, META_PIXEL_EVENTS } from "@/lib/metaPixel";
 
 import heroMobile1x from "@/public/images/bg-hero-mobile-378x284.webp";
 import heroMobile2x from "@/public/images/bg-hero-mobile-480x879.webp";
@@ -251,6 +252,19 @@ const HeroSection = () => {
             end_date: formData.end_date,
             location: formData.location || undefined,
             car_type: formData.car_type || undefined,
+        });
+
+        const searchString = [formData.location, formData.car_type]
+            .filter((value) => typeof value === "string" && value.trim().length > 0)
+            .join(" | ");
+
+        trackMetaPixelEvent(META_PIXEL_EVENTS.SEARCH, {
+            search_source: "hero_form",
+            start_date: formData.start_date || undefined,
+            end_date: formData.end_date || undefined,
+            location: formData.location || undefined,
+            car_type: formData.car_type || undefined,
+            search_string: searchString.length > 0 ? searchString : undefined,
         });
 
         router.push(`/cars?${params.toString()}`);

--- a/components/MetaPixelInitializer.tsx
+++ b/components/MetaPixelInitializer.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { initMetaPixel, trackMetaPixelPageView, isMetaPixelConfigured } from "@/lib/metaPixel";
+
+const MetaPixelInitializer = () => {
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+    const hasTrackedInitialRef = useRef(false);
+
+    const searchParamsKey = useMemo(() => {
+        if (!searchParams) {
+            return "";
+        }
+        return searchParams.toString();
+    }, [searchParams]);
+
+    useEffect(() => {
+        initMetaPixel();
+    }, []);
+
+    useEffect(() => {
+        if (!isMetaPixelConfigured()) {
+            return;
+        }
+
+        if (!hasTrackedInitialRef.current) {
+            hasTrackedInitialRef.current = true;
+            return;
+        }
+
+        trackMetaPixelPageView();
+    }, [pathname, searchParamsKey]);
+
+    return null;
+};
+
+export default MetaPixelInitializer;
+

--- a/components/MetaPixelScript.tsx
+++ b/components/MetaPixelScript.tsx
@@ -1,0 +1,39 @@
+import Script from "next/script";
+
+const pixelId = process.env.NEXT_PUBLIC_META_PIXEL_ID;
+
+const MetaPixelScript = () => {
+    if (!pixelId) {
+        return null;
+    }
+
+    const snippet = `!function(f,b,e,v,n,t,s){
+  if(f.fbq)return; n=f.fbq=function(){ n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+  if(!f._fbq)f._fbq=n;
+  n.push=n; n.loaded=!0; n.version='2.0';
+  n.queue=[]; t=b.createElement(e); t.async=!0;
+  t.src=v; s=b.getElementsByTagName(e)[0];
+  s.parentNode?.insertBefore(t,s);
+}(window, document,'script','https://connect.facebook.net/en_US/fbevents.js');
+fbq('init', '${pixelId}');
+fbq('consent', 'grant');
+fbq('track', 'PageView');`;
+
+    const noscriptMarkup = `
+  <img height="1" width="1" style="display:none" alt=""
+       src="https://www.facebook.com/tr?id=${pixelId}&ev=PageView&noscript=1" />
+`;
+
+    return (
+        <>
+            <Script id="meta-pixel" strategy="afterInteractive">
+                {snippet}
+            </Script>
+            <noscript dangerouslySetInnerHTML={{ __html: noscriptMarkup }} />
+        </>
+    );
+};
+
+export default MetaPixelScript;
+

--- a/components/cars/CarsPageClient.tsx
+++ b/components/cars/CarsPageClient.tsx
@@ -610,7 +610,7 @@ const FleetPage = () => {
         }));
         const contentIds = contents
             .map((item) => item.content_id)
-            .filter((id): id is number | string => id !== undefined && id !== null)
+            .filter((id): id is number => id !== undefined && id !== null)
             .map((id) => String(id));
 
         trackTikTokEvent(TIKTOK_EVENTS.VIEW_CONTENT, {

--- a/components/cars/CarsPageClient.tsx
+++ b/components/cars/CarsPageClient.tsx
@@ -18,6 +18,7 @@ import { ApiCar, Car, CarCategory, type CarSearchUiPayload } from "@/types/car";
 import { useTranslations } from "@/lib/i18n/useTranslations";
 import { trackMixpanelEvent } from "@/lib/mixpanelClient";
 import { trackTikTokEvent, TIKTOK_EVENTS } from "@/lib/tiktokPixel";
+import { trackMetaPixelEvent, META_PIXEL_EVENTS } from "@/lib/metaPixel";
 
 const siteUrl = siteMetadata.siteUrl;
 const fleetPageUrl = `${siteUrl}/cars`;
@@ -448,6 +449,17 @@ const FleetPage = () => {
             page: 1,
             total_results: totalCars,
         });
+
+        trackMetaPixelEvent(META_PIXEL_EVENTS.SEARCH, {
+            search_string: searchTerm || undefined,
+            content_category: "fleet_filters",
+            content_type: "car_fleet",
+            filter_key: key,
+            filter_value: value,
+            sort_by: sortBy,
+            page: 1,
+            total_results: totalCars,
+        });
     };
 
     const clearFilters = () => {
@@ -538,6 +550,25 @@ const FleetPage = () => {
             with_deposit: withDeposit,
         });
 
+        trackMetaPixelEvent(META_PIXEL_EVENTS.ADD_TO_CART, {
+            content_ids: [String(car.id)],
+            content_name: car.name,
+            content_type: "car",
+            contents: [
+                {
+                    id: String(car.id),
+                    quantity: 1,
+                    item_price: totalAmount ?? undefined,
+                    title: car.name,
+                },
+            ],
+            value: totalAmount ?? undefined,
+            currency: "RON",
+            start_date: startDate || undefined,
+            end_date: endDate || undefined,
+            with_deposit: withDeposit,
+        });
+
         router.push(hasCompleteBookingRange ? "/checkout" : "/");
     };
 
@@ -568,6 +599,20 @@ const FleetPage = () => {
             };
         });
 
+        const metaContents = contents.map((item) => ({
+            id:
+                item.content_id !== undefined && item.content_id !== null
+                    ? String(item.content_id)
+                    : undefined,
+            quantity: item.quantity,
+            item_price: item.price,
+            title: item.content_name,
+        }));
+        const contentIds = contents
+            .map((item) => item.content_id)
+            .filter((id): id is number | string => id !== undefined && id !== null)
+            .map((id) => String(id));
+
         trackTikTokEvent(TIKTOK_EVENTS.VIEW_CONTENT, {
             content_type: "car_fleet",
             contents,
@@ -575,6 +620,17 @@ const FleetPage = () => {
             value: contents[0]?.price ?? undefined,
             total_results: totalCars,
             search_term: searchTerm || undefined,
+            sort_by: sortBy,
+        });
+
+        trackMetaPixelEvent(META_PIXEL_EVENTS.VIEW_CONTENT, {
+            content_type: "car_fleet",
+            content_ids: contentIds,
+            contents: metaContents,
+            currency: "RON",
+            value: contents[0]?.price ?? undefined,
+            total_results: totalCars,
+            search_string: searchTerm || undefined,
             sort_by: sortBy,
         });
 

--- a/components/home/HomePageClient.tsx
+++ b/components/home/HomePageClient.tsx
@@ -14,6 +14,7 @@ import { useBooking } from "@/context/useBooking";
 import type { WheelOfFortunePeriod } from "@/types/wheel";
 import { trackMixpanelEvent } from "@/lib/mixpanelClient";
 import { trackTikTokEvent, TIKTOK_EVENTS } from "@/lib/tiktokPixel";
+import { trackMetaPixelEvent, META_PIXEL_EVENTS } from "@/lib/metaPixel";
 
 const ElfsightWidget = dynamic(() => import("@/components/ElfsightWidget"), {
     ssr: false,
@@ -253,6 +254,16 @@ const HomePageClient = () => {
         });
 
         trackTikTokEvent(TIKTOK_EVENTS.VIEW_CONTENT, {
+            content_type: "landing_page",
+            has_booking_range: Boolean(hasBookingRange),
+            booking_range_key: bookingRangeKey || undefined,
+            wheel_popup_shown: Boolean(showWheelPopup),
+            wheel_period_id: activePeriod?.id ?? undefined,
+        });
+
+        trackMetaPixelEvent(META_PIXEL_EVENTS.VIEW_CONTENT, {
+            content_name: "Landing Page",
+            content_category: "home",
             content_type: "landing_page",
             has_booking_range: Boolean(hasBookingRange),
             booking_range_key: bookingRangeKey || undefined,

--- a/docs/meta-pixel.md
+++ b/docs/meta-pixel.md
@@ -1,0 +1,31 @@
+# Configurare și evenimente Meta Pixel (Facebook)
+
+Integrarea Meta Pixel rulează global prin `MetaPixelScript` și `MetaPixelInitializer`, încărcate în `app/layout.tsx`. Pentru activare este necesară variabila de mediu publică `NEXT_PUBLIC_META_PIXEL_ID`. Dacă variabila lipsește, scriptul nu este injectat, iar apelurile `trackMetaPixelEvent`/`trackMetaPixelPageView` sunt ignorate în siguranță.
+
+## Evenimente urmărite
+
+| Eveniment Meta | Trigger în aplicație | Fișier sursă | Proprietăți trimise |
+| -------------- | -------------------- | ------------ | -------------------- |
+| `PageView` | La fiecare schimbare de rută în App Router (după prima încărcare) | `components/MetaPixelInitializer.tsx` | – |
+| `ViewContent` | 1) prima încărcare a paginii de flotă cu rezultate; 2) afișarea landing page-ului public | `components/cars/CarsPageClient.tsx`, `components/home/HomePageClient.tsx` | `content_type`, `content_ids`, `contents`, `value`, `currency`, `total_results`, `search_string`, `sort_by`, `booking_range_key`, `wheel_period_id`, `wheel_popup_shown`. |
+| `Search` | Căutări din hero form și ajustări de filtre pe pagina flotei | `components/HeroSection.tsx`, `components/cars/CarsPageClient.tsx` | `search_source`, `search_string`, `content_type`, `content_category`, `filter_key`, `filter_value`, `location`, `car_type`, `start_date`, `end_date`, `page`, `sort_by`, `total_results`. |
+| `AddToCart` | Click pe CTA-ul unei mașini pentru a continua spre checkout | `components/cars/CarsPageClient.tsx` | `content_ids`, `content_name`, `content_type`, `contents`, `value`, `currency`, `start_date`, `end_date`, `with_deposit`. |
+| `InitiateCheckout` | Prima încărcare completă a checkout-ului (când există mașină și interval valid) | `app/checkout/page.tsx` | `value`, `currency`, `content_ids`, `content_name`, `content_type`, `contents`, `start_date`, `end_date`, `with_deposit`, `service_ids`, `applied_offer_ids`. |
+| `Lead` | Trimiterea formularului de rezervare din checkout | `app/checkout/page.tsx` | `form_name`, `value`, `currency`, `content_ids`, `content_name`, `content_type`, `contents`, `with_deposit`, `start_date`, `end_date`, `service_ids`, `applied_offer_ids`. |
+| `Purchase` | Afișarea paginii de succes după rezervare (odată pe sesiune) | `app/success/page.tsx` | `value`, `currency`, `content_ids`, `content_name`, `content_type`, `contents`, `reservation_id`, `start_date`, `end_date`, `with_deposit`, `service_ids`. |
+| `Contact` | Click pe telefon, WhatsApp sau email în secțiunea de contact | `components/ContactSection.tsx` | `contact_method`, `value`. |
+
+Toate payload-urile sunt igienizate în `lib/metaPixel.ts` pentru a elimina valori `undefined`, liste goale sau date invalide înainte de trimiterea către Facebook.
+
+## Pași de validare
+
+1. Adaugă `NEXT_PUBLIC_META_PIXEL_ID` în `.env.local`.
+2. Rulează aplicația (`npm run dev`) și verifică în browser, cu Meta Pixel Helper, că evenimentele de mai sus apar cu status „Received”.
+3. Pentru scenariile checkout/succes, folosește fluxul complet din pagina „Flotă” pentru a popula `BookingContext` (selectează mașină, perioadă, finalizează formularul). Evenimentele `Lead` și `Purchase` se trimit doar după completarea integrală a procesului.
+
+## Extensii recomandate
+
+- **Advanced Matching** – dacă backend-ul acceptă hashing pentru email/telefon, se poate extinde `initMetaPixel` pentru a apela `fbq('init', ID, { em: hashEmail, ph: hashPhone })` folosind datele introduse în checkout.
+- **Evenimente suplimentare** – pentru formulare noi (ex. newsletter, demo drive) reutilizează `trackMetaPixelEvent` cu evenimente standard (`CompleteRegistration`, `Subscribe` etc.).
+- **Debugging** – în dezvoltare poți activa `fbq('trackCustom', 'DebugEvent', {...})` din componente locale pentru a valida payload-uri noi fără a afecta rapoartele de producție.
+

--- a/lib/metaPixel.ts
+++ b/lib/metaPixel.ts
@@ -1,0 +1,195 @@
+const META_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID;
+
+type MetaPixelMethod = (...args: Array<unknown>) => void;
+
+type MetaPixelFunction = MetaPixelMethod & {
+    push: MetaPixelMethod;
+    queue: Array<unknown>;
+    callMethod?: MetaPixelMethod;
+    loaded?: boolean;
+    version?: string;
+};
+
+declare global {
+    interface Window {
+        fbq?: MetaPixelFunction;
+        _fbq?: MetaPixelFunction;
+    }
+}
+
+const isBrowser = typeof window !== "undefined";
+
+const hasPixelId = (): boolean => Boolean(META_PIXEL_ID && META_PIXEL_ID.trim().length > 0);
+
+const ensureQueue = (): MetaPixelFunction | null => {
+    if (!isBrowser) {
+        return null;
+    }
+
+    if (!hasPixelId()) {
+        return null;
+    }
+
+    const existing = window.fbq;
+    if (existing && typeof existing === "function") {
+        return existing;
+    }
+
+    const queue = function (...args: Array<unknown>) {
+        if (queue.callMethod) {
+            queue.callMethod(...args);
+        } else {
+            queue.queue.push(args);
+        }
+    } as MetaPixelFunction;
+
+    queue.push = function (...args: Array<unknown>) {
+        queue(...args);
+    };
+    queue.queue = [];
+    queue.loaded = false;
+    queue.version = "2.0";
+
+    window.fbq = queue;
+
+    return queue;
+};
+
+const resolveQueue = (): MetaPixelFunction | null => {
+    if (!isBrowser) {
+        return null;
+    }
+
+    if (!hasPixelId()) {
+        return null;
+    }
+
+    const queue = ensureQueue();
+    if (!queue) {
+        return null;
+    }
+
+    if (typeof queue !== "function") {
+        return null;
+    }
+
+    return queue;
+};
+
+const sanitizeValue = (value: unknown): unknown => {
+    if (value === undefined || value === null) {
+        return undefined;
+    }
+
+    if (Array.isArray(value)) {
+        const sanitizedArray = value
+            .map((entry) => sanitizeValue(entry))
+            .filter((entry): entry is Exclude<ReturnType<typeof sanitizeValue>, undefined> => entry !== undefined);
+
+        return sanitizedArray.length > 0 ? sanitizedArray : undefined;
+    }
+
+    if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? undefined : value.toISOString();
+    }
+
+    if (typeof value === "object") {
+        const entries = Object.entries(value as Record<string, unknown>)
+            .reduce<Array<readonly [string, unknown]>>((acc, [key, entryValue]) => {
+                const sanitizedEntry = sanitizeValue(entryValue);
+                if (sanitizedEntry === undefined) {
+                    return acc;
+                }
+
+                acc.push([key, sanitizedEntry] as const);
+                return acc;
+            }, []);
+
+        if (entries.length === 0) {
+            return undefined;
+        }
+
+        return Object.fromEntries(entries);
+    }
+
+    return value;
+};
+
+const sanitizePayload = (payload?: Record<string, unknown>): Record<string, unknown> | undefined => {
+    if (!payload) {
+        return undefined;
+    }
+
+    const sanitized = sanitizeValue(payload);
+    if (!sanitized || typeof sanitized !== "object") {
+        return undefined;
+    }
+
+    return sanitized as Record<string, unknown>;
+};
+
+export const META_PIXEL_EVENTS = {
+    PAGE_VIEW: "PageView",
+    VIEW_CONTENT: "ViewContent",
+    SEARCH: "Search",
+    ADD_TO_CART: "AddToCart",
+    INITIATE_CHECKOUT: "InitiateCheckout",
+    LEAD: "Lead",
+    CONTACT: "Contact",
+    PURCHASE: "Purchase",
+} as const;
+
+export type MetaPixelEventName = (typeof META_PIXEL_EVENTS)[keyof typeof META_PIXEL_EVENTS];
+
+export const initMetaPixel = () => {
+    ensureQueue();
+};
+
+export const trackMetaPixelPageView = () => {
+    const queue = resolveQueue();
+    if (!queue) {
+        return;
+    }
+
+    try {
+        queue("track", META_PIXEL_EVENTS.PAGE_VIEW);
+    } catch (error) {
+        if (process.env.NODE_ENV !== "production") {
+            console.warn("Nu s-a putut trimite PageView către Meta Pixel", error);
+        }
+    }
+};
+
+export const trackMetaPixelEvent = (
+    eventName: MetaPixelEventName,
+    payload?: Record<string, unknown>,
+) => {
+    const queue = resolveQueue();
+    if (!queue) {
+        return;
+    }
+
+    if (typeof eventName !== "string" || eventName.trim().length === 0) {
+        if (process.env.NODE_ENV !== "production") {
+            console.warn("Eveniment Meta Pixel ignorat – nume invalid", eventName);
+        }
+        return;
+    }
+
+    const sanitizedPayload = sanitizePayload(payload);
+
+    try {
+        if (sanitizedPayload) {
+            queue("track", eventName, sanitizedPayload);
+        } else {
+            queue("track", eventName);
+        }
+    } catch (error) {
+        if (process.env.NODE_ENV !== "production") {
+            console.warn(`Nu s-a putut trimite evenimentul Meta Pixel ${eventName}`, error);
+        }
+    }
+};
+
+export const isMetaPixelConfigured = () => hasPixelId();
+


### PR DESCRIPTION
## Summary
- add Meta Pixel loader and client utilities to initialize the pixel globally
- emit Meta Pixel events alongside existing analytics across landing, search, contact, checkout and success flows
- document the Meta Pixel setup and expose the new environment variable in the README

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e3da890f988329a8fe0b92c1d8f913