### PR TITLE
Fix TikTok Pixel content_type parameter

### DIFF
--- a/components/cars/CarsPageClient.tsx
+++ b/components/cars/CarsPageClient.tsx
@@ -17,7 +17,7 @@ import { useBooking } from "@/context/useBooking";
 import { ApiCar, Car, CarCategory, type CarSearchUiPayload } from "@/types/car";
 import { useTranslations } from "@/lib/i18n/useTranslations";
 import { trackMixpanelEvent } from "@/lib/mixpanelClient";
-import { trackTikTokEvent, TIKTOK_EVENTS } from "@/lib/tiktokPixel";
+import { trackTikTokEvent, TIKTOK_CONTENT_TYPE, TIKTOK_EVENTS } from "@/lib/tiktokPixel";
 import { trackMetaPixelEvent, META_PIXEL_EVENTS } from "@/lib/metaPixel";
 
 const siteUrl = siteMetadata.siteUrl;
@@ -534,7 +534,7 @@ const FleetPage = () => {
         });
 
         trackTikTokEvent(TIKTOK_EVENTS.ADD_TO_CART, {
-            content_type: "car",
+            content_type: TIKTOK_CONTENT_TYPE,
             contents: [
                 {
                     content_id: car.id,
@@ -614,7 +614,7 @@ const FleetPage = () => {
             .map((id) => String(id));
 
         trackTikTokEvent(TIKTOK_EVENTS.VIEW_CONTENT, {
-            content_type: "car_fleet",
+            content_type: TIKTOK_CONTENT_TYPE,
             contents,
             currency: "RON",
             value: contents[0]?.price ?? undefined,

--- a/components/home/HomePageClient.tsx
+++ b/components/home/HomePageClient.tsx
@@ -13,7 +13,7 @@ import { extractArray, isPeriodActive, mapPeriod } from "@/lib/wheelNormalizatio
 import { useBooking } from "@/context/useBooking";
 import type { WheelOfFortunePeriod } from "@/types/wheel";
 import { trackMixpanelEvent } from "@/lib/mixpanelClient";
-import { trackTikTokEvent, TIKTOK_EVENTS } from "@/lib/tiktokPixel";
+import { trackTikTokEvent, TIKTOK_CONTENT_TYPE, TIKTOK_EVENTS } from "@/lib/tiktokPixel";
 import { trackMetaPixelEvent, META_PIXEL_EVENTS } from "@/lib/metaPixel";
 
 const ElfsightWidget = dynamic(() => import("@/components/ElfsightWidget"), {
@@ -254,7 +254,7 @@ const HomePageClient = () => {
         });
 
         trackTikTokEvent(TIKTOK_EVENTS.VIEW_CONTENT, {
-            content_type: "landing_page",
+            content_type: TIKTOK_CONTENT_TYPE,
             has_booking_range: Boolean(hasBookingRange),
             booking_range_key: bookingRangeKey || undefined,
             wheel_popup_shown: Boolean(showWheelPopup),

--- a/docs/tiktok-pixel.md
+++ b/docs/tiktok-pixel.md
@@ -7,13 +7,15 @@ Integrarea TikTok Pixel rulează global prin `TikTokPixelScript` și `TikTokPixe
 | Eveniment TikTok | Trigger în aplicație | Fișier sursă | Proprietăți trimise |
 | ---------------- | -------------------- | ------------ | -------------------- |
 | `PageView` | La fiecare schimbare de rută în App Router | `components/TikTokPixelInitializer.tsx` | Nu are payload suplimentar. |
-| `ViewContent` | 1) prima încărcare a paginii de flotă cu rezultate; 2) afișarea landing page-ului public | `components/cars/CarsPageClient.tsx`, `components/home/HomePageClient.tsx` | `content_type`, `contents` (primele modele afișate), `value`, `currency`, `total_results`, `search_term`, `sort_by`. |
+| `ViewContent` | 1) prima încărcare a paginii de flotă cu rezultate; 2) afișarea landing page-ului public | `components/cars/CarsPageClient.tsx`, `components/home/HomePageClient.tsx` | `content_type` (`"vehicle"`), `contents` (primele modele afișate), `value`, `currency`, `total_results`, `search_term`, `sort_by`. |
 | `Search` | Căutări din hero form și ajustări de filtre pe pagina flotei | `components/HeroSection.tsx`, `components/cars/CarsPageClient.tsx` | `search_type`, `filter_key`, `filter_value`, `location`, `start_date`, `end_date`, `search_term`, `sort_by`, `page`, `total_results`. |
-| `AddToCart` | Click pe CTA-ul unei mașini pentru a continua spre checkout | `components/cars/CarsPageClient.tsx` | `content_type`, `contents` (mașina selectată), `value`, `currency`, `start_date`, `end_date`, `with_deposit`. |
+| `AddToCart` | Click pe CTA-ul unei mașini pentru a continua spre checkout | `components/cars/CarsPageClient.tsx` | `content_type` (`"vehicle"`), `contents` (mașina selectată), `value`, `currency`, `start_date`, `end_date`, `with_deposit`. |
 | `InitiateCheckout` | Prima încărcare completă a checkout-ului (când există mașină și interval valid) | `app/checkout/page.tsx` | `value`, `currency`, `contents`, `start_date`, `end_date`, `with_deposit`, `service_ids`, `applied_offer_ids`. |
 | `SubmitForm` | Trimiterea formularului de rezervare din checkout | `app/checkout/page.tsx` | `form_name`, `value`, `currency`, `with_deposit`, `start_date`, `end_date`, `contents`, `service_ids`, `applied_offer_ids`. |
 | `CompletePayment` | Afișarea paginii de succes după rezervare (odată pe sesiune) | `app/success/page.tsx` | `value`, `currency`, `contents`, `reservation_id`, `start_date`, `end_date`, `with_deposit`, `service_ids`. |
 | `Contact` | Click pe telefon, WhatsApp sau email în secțiunea de contact | `components/ContactSection.tsx` | `contact_method`, `value`. |
+
+Valoarea `content_type` este standardizată în cod prin constanta `TIKTOK_CONTENT_TYPE` (`"vehicle"`) din `lib/tiktokPixel.ts`.
 
 Toate payload-urile sunt igienizate în `lib/tiktokPixel.ts` pentru a elimina valorile `undefined`, liste goale sau date invalide înainte de a fi trimise către TikTok.
 

--- a/lib/tiktokPixel.ts
+++ b/lib/tiktokPixel.ts
@@ -112,6 +112,8 @@ export const TIKTOK_EVENTS = {
 
 export type TikTokEventName = (typeof TIKTOK_EVENTS)[keyof typeof TIKTOK_EVENTS];
 
+export const TIKTOK_CONTENT_TYPE = "vehicle" as const;
+
 export const initTikTokPixel = () => {
     if (!isBrowser) {
         return;


### PR DESCRIPTION
## Summary
- standardize the TikTok Pixel payloads to use the allowed `vehicle` content type constant
- update the home and fleet pages to reference the shared TikTok content type helper
- document the standard content type usage in the TikTok Pixel integration guide

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3f11c13808329b7b9b478d33ffc28