### PR TITLE
Improve hero LCP by prioritizing background image

### DIFF
--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -295,7 +295,7 @@ const HeroSection = () => {
                         alt="Fundal aeroport"
                         fill
                         placeholder="blur"
-                        loading="lazy"
+                        priority
                         sizes="(max-width: 639px) 0px, 100vw"
                         quality={70}
                         className="object-cover"


### PR DESCRIPTION
## Summary
- ensure the desktop hero background image loads eagerly by enabling Next.js priority to improve Largest Contentful Paint on larger screens

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e3f80757608329894ba3a776446b66