### PR TITLE
Optimize hero image loading

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -91,6 +91,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           rel="preload"
           as="image"
           href="/images/bg-hero-mobile-960x1759.webp"
+          media="(max-width: 639px)"
           imageSrcSet="/images/bg-hero-mobile-378x284.webp 378w, /images/bg-hero-mobile-480x879.webp 480w, /images/bg-hero-mobile-960x1759.webp 960w"
           imageSizes="100vw"
         />

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -64,10 +64,10 @@ const HeroSection = () => {
                         src={heroMobile2x}
                         alt="Fundal aeroport"
                         fill
-                        priority
                         fetchPriority="high"
+                        loading="eager"
                         placeholder="blur"
-                        sizes="100vw"
+                        sizes="(max-width: 639px) 100vw, 0vw"
                         quality={60}
                         className="object-cover"
                     />
@@ -78,9 +78,9 @@ const HeroSection = () => {
                         alt="Fundal aeroport"
                         fill
                         placeholder="blur"
-                        priority
+                        loading="lazy"
                         fetchPriority="high"
-                        sizes="100vw"
+                        sizes="(min-width: 640px) 100vw, 0vw"
                         quality={60}
                         className="object-cover"
                     />


### PR DESCRIPTION
## Summary
- add a media query to the mobile hero preload so it only runs on small screens
- stop preloading the desktop hero image on mobile and refine responsive sizes to avoid unnecessary downloads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e42e0959748329bca929295624ab17