### PR TITLE
Ensure TikTok pixel sends content identifiers

### DIFF
--- a/components/HeroBookingForm.tsx
+++ b/components/HeroBookingForm.tsx
@@ -251,6 +251,7 @@ const HeroBookingForm = ({
         trackTikTokEvent(TIKTOK_EVENTS.SUBMIT_FORM, {
             contents: [
                 {
+                    content_id: "hero_booking_form",
                     content_name: "booking", // eslint-disable-line camelcase -- cerință pixel TikTok
                 },
             ],

--- a/components/home/HomePageClient.tsx
+++ b/components/home/HomePageClient.tsx
@@ -295,6 +295,8 @@ const HomePageClient = () => {
                 });
 
                 trackTikTokEvent(TIKTOK_EVENTS.VIEW_CONTENT, {
+                    content_id: "landing_home",
+                    content_name: "Landing Page",
                     content_type: TIKTOK_CONTENT_TYPE,
                     has_booking_range: Boolean(hasBookingRange),
                     booking_range_key: bookingRangeKey || undefined,


### PR DESCRIPTION
## Summary
- derive TikTok `content_id`/`content_ids` values from provided contents before dispatching events
- tag the landing and hero form events with stable content identifiers so the pixel receives them consistently

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e4312f965c8329b35efbf5dd8e11c6