### PR TITLE
Fix hydration mismatch by delaying Tailwind critical style cleanup

### DIFF
--- a/app/global-styles.tsx
+++ b/app/global-styles.tsx
@@ -19,23 +19,6 @@ if (isProduction) {
   }
 }
 
-const asyncCssScript = `(() => {
-  const link = document.querySelector('link[data-async-css="tailwind"]');
-  if (!link || !(link instanceof HTMLLinkElement)) return;
-  if (link.media === 'all') return;
-  const critical = document.getElementById('critical-tailwind');
-  const enable = () => {
-    link.media = 'all';
-    if (critical && critical.parentNode) {
-      critical.parentNode.removeChild(critical);
-    }
-  };
-  link.addEventListener('load', enable, { once: true });
-  if (link.sheet) {
-    enable();
-  }
-})();`;
-
 const noscriptStyles = '<link rel="stylesheet" href="/tailwind.css" />';
 
 export function GlobalStyles(): JSX.Element | null {
@@ -65,7 +48,6 @@ export function GlobalStyles(): JSX.Element | null {
         media="print"
         data-async-css="tailwind"
       />
-      <script dangerouslySetInnerHTML={{ __html: asyncCssScript }} />
       <noscript dangerouslySetInnerHTML={{ __html: noscriptStyles }} />
     </>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,7 @@ import { buildMetadata } from "@/lib/seo/meta";
 import { siteMetadata } from "@/lib/seo/siteMetadata";
 import { GlobalStyles } from "./global-styles";
 import { AVAILABLE_LOCALES, LOCALE_STORAGE_KEY, DEFAULT_LOCALE } from "@/lib/i18n/config";
+import TailwindStylesheetManager from "../components/TailwindStylesheetManager";
 import MixpanelInitializer from "../components/MixpanelInitializer";
 import TikTokPixelScript from "../components/TikTokPixelScript";
 import TikTokPixelInitializer from "../components/TikTokPixelInitializer";
@@ -125,6 +126,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       </head>
       <body className="min-h-screen bg-white">
         <Suspense fallback={null}>
+          <TailwindStylesheetManager />
           <MixpanelInitializer />
           <TikTokPixelInitializer />
           <MetaPixelInitializer />

--- a/components/TailwindStylesheetManager.tsx
+++ b/components/TailwindStylesheetManager.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+
+const TAILWIND_ASYNC_SELECTOR = 'link[data-async-css="tailwind"]';
+const CRITICAL_STYLE_ID = "critical-tailwind";
+
+const TailwindStylesheetManager = () => {
+    useEffect(() => {
+        const link = document.querySelector<HTMLLinkElement>(TAILWIND_ASYNC_SELECTOR);
+        if (!link) {
+            return;
+        }
+
+        const critical = document.getElementById(CRITICAL_STYLE_ID);
+
+        const enableStylesheet = () => {
+            if (link.media !== "all") {
+                link.media = "all";
+            }
+            if (critical && critical.parentNode) {
+                critical.parentNode.removeChild(critical);
+            }
+        };
+
+        if (link.sheet) {
+            enableStylesheet();
+            return;
+        }
+
+        const handleLoad = () => {
+            enableStylesheet();
+        };
+
+        link.addEventListener("load", handleLoad, { once: true });
+
+        const timeout = window.setTimeout(() => {
+            enableStylesheet();
+        }, 3000);
+
+        return () => {
+            link.removeEventListener("load", handleLoad);
+            window.clearTimeout(timeout);
+        };
+    }, []);
+
+    return null;
+};
+
+export default TailwindStylesheetManager;


### PR DESCRIPTION
## Summary
- prevent the inline Tailwind script from mutating the DOM before hydration by removing it from `GlobalStyles`
- add a client-only Tailwind stylesheet manager that enables the async CSS link and cleans up the critical style after hydration
- register the manager in the root layout so hydration completes before the inline style is removed

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e43a084b988329a1d0bd6b109fce76