### PR TITLE
Prevent duplicate Meta Pixel page views on initial load

### DIFF
--- a/components/MetaPixelInitializer.tsx
+++ b/components/MetaPixelInitializer.tsx
@@ -7,7 +7,11 @@ import { initMetaPixel, trackMetaPixelPageView, isMetaPixelConfigured } from "@/
 const MetaPixelInitializer = () => {
     const pathname = usePathname();
     const searchParams = useSearchParams();
-    const hasTrackedInitialRef = useRef(false);
+    const hasInitializedRef = useRef(false);
+    const previousLocationRef = useRef<{ pathname: string; searchParamsKey: string }>({
+        pathname: "",
+        searchParamsKey: "",
+    });
 
     const searchParamsKey = useMemo(() => {
         if (!searchParams) {
@@ -25,10 +29,31 @@ const MetaPixelInitializer = () => {
             return;
         }
 
-        if (!hasTrackedInitialRef.current) {
-            hasTrackedInitialRef.current = true;
+        const normalizedPathname = typeof pathname === "string" ? pathname : "";
+        const normalizedSearchParamsKey = typeof searchParamsKey === "string" ? searchParamsKey : "";
+
+        if (!hasInitializedRef.current) {
+            hasInitializedRef.current = true;
+            previousLocationRef.current = {
+                pathname: normalizedPathname,
+                searchParamsKey: normalizedSearchParamsKey,
+            };
             return;
         }
+
+        const { pathname: previousPathname, searchParamsKey: previousSearchParamsKey } = previousLocationRef.current;
+
+        if (
+            previousPathname === normalizedPathname &&
+            previousSearchParamsKey === normalizedSearchParamsKey
+        ) {
+            return;
+        }
+
+        previousLocationRef.current = {
+            pathname: normalizedPathname,
+            searchParamsKey: normalizedSearchParamsKey,
+        };
 
         trackMetaPixelPageView();
     }, [pathname, searchParamsKey]);


### PR DESCRIPTION
## Summary
- ensure the Meta Pixel route-change tracker stores the initial location instead of firing on hydration
- skip duplicate PageView events when the pathname and search params have not changed

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e4bc683ef48329874ae2a26b7eacf7