### PR TITLE
Fix hydration error on homepage hero booking form

### DIFF
--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -27,7 +27,6 @@ const HeroBookingFormSkeleton = () => (
 const HeroBookingForm = dynamic<HeroBookingFormProps>(
     () => import("./HeroBookingForm"),
     {
-        ssr: false,
         loading: () => <HeroBookingFormSkeleton />,
     },
 );


### PR DESCRIPTION
## Summary
- allow the homepage HeroBookingForm to render on the server so the initial HTML matches the hydrated client output

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e4bf4e81948329887ffacf1cff2c25