### PR TITLE
Track lead events on success page

### DIFF
--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -135,7 +135,7 @@ const SuccessPage = () => {
                   .filter((id): id is number => typeof id === "number" && Number.isFinite(id))
             : [];
 
-        trackTikTokEvent(TIKTOK_EVENTS.COMPLETE_PAYMENT, {
+        trackTikTokEvent(TIKTOK_EVENTS.LEAD, {
             value: totalAmount ?? undefined,
             currency: DEFAULT_CURRENCY,
             contents: [
@@ -162,7 +162,7 @@ const SuccessPage = () => {
         const carIdString =
             carId !== undefined && carId !== null ? String(carId) : undefined;
 
-        trackMetaPixelEvent(META_PIXEL_EVENTS.PURCHASE, {
+        trackMetaPixelEvent(META_PIXEL_EVENTS.LEAD, {
             value: totalAmount ?? undefined,
             currency: DEFAULT_CURRENCY,
             content_ids: carIdString ? [carIdString] : undefined,

--- a/lib/tiktokPixel.ts
+++ b/lib/tiktokPixel.ts
@@ -172,6 +172,7 @@ export const TIKTOK_EVENTS = {
     ADD_TO_CART: "AddToCart",
     INITIATE_CHECKOUT: "InitiateCheckout",
     SUBMIT_FORM: "SubmitForm",
+    LEAD: "Lead",
     COMPLETE_PAYMENT: "CompletePayment",
     CONTACT: "Contact",
 } as const;


### PR DESCRIPTION
## Rezumat
- actualizează evenimentul trimis din pagina de succes către TikTok Pixel la Lead
- înlocuiește evenimentul Purchase cu Lead pentru Meta Pixel în aceeași pagină

## Teste
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68e4c0ed94d883298983f77eae5c468f