### PR TITLE
Adjust booking summary to show original prices when discount applied

### DIFF
--- a/app/admin/bookings/page.tsx
+++ b/app/admin/bookings/page.tsx
@@ -43,6 +43,7 @@ import {
   describeWheelPrizeSummaryAmount,
   formatWheelPrizeExpiry,
 } from "@/lib/wheelFormatting";
+import { generatePaginationSequence } from "@/lib/pagination";
 
 const EMPTY_BOOKING = createEmptyBookingForm();
 
@@ -732,6 +733,10 @@ const ReservationsPage = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [lastPage, setLastPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
+  const paginationSegments = React.useMemo(
+    () => generatePaginationSequence(currentPage, lastPage),
+    [currentPage, lastPage],
+  );
   const [totalReservations, setTotalReservations] = useState(0);
   const [contractOpen, setContractOpen] = useState(false);
   const [contractReservation, setContractReservation] =
@@ -1274,13 +1279,6 @@ const ReservationsPage = () => {
     );
   };
 
-  const getPageNumbers = (): (number | "ellipsis")[] => {
-    if (lastPage <= 6) {
-      return Array.from({ length: lastPage }, (_, i) => i + 1);
-    }
-    return [1, 2, 3, "ellipsis", lastPage - 2, lastPage - 1, lastPage];
-  };
-
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
@@ -1505,7 +1503,7 @@ const ReservationsPage = () => {
               >
                 Anterior
               </button>
-              {getPageNumbers().map((page, idx) =>
+              {paginationSegments.map((page, idx) =>
                 page === "ellipsis" ? (
                   <span key={`ellipsis-${idx}`} className="px-2 py-1">
                     ...

--- a/components/admin/BookingForm.tsx
+++ b/components/admin/BookingForm.tsx
@@ -1407,8 +1407,10 @@ const BookingForm: React.FC<BookingFormProps> = ({
                         ...prev,
                         days: typeof data.days === "number" ? data.days : prev.days ?? 0,
                         price_per_day: normalizedSelectedRate ?? prev.price_per_day,
-                        original_price_per_day:
-                            normalizedSelectedRate ?? prevOriginalPrice ?? prev.original_price_per_day ?? prev.price_per_day ?? null,
+                        original_price_per_day: prevOriginalPrice ??
+                            (typeof prevPricePerDay === "number" && Number.isFinite(prevPricePerDay)
+                                ? Math.round(prevPricePerDay * 100) / 100
+                                : normalizedSelectedRate ?? null),
                         base_price: normalizedDepositRate ?? prev.base_price ?? data.base_price ?? null,
                         base_price_casco: normalizedCascoRate ?? prev.base_price_casco ?? data.base_price_casco ?? null,
                         sub_total: typeof nextSubtotal === "number" ? nextSubtotal : prev.sub_total,
@@ -2419,12 +2421,12 @@ const BookingForm: React.FC<BookingFormProps> = ({
                                                           ? parsePrice(quote.rental_rate)
                                                           : prev.price_per_day,
                                                 original_price_per_day:
-                                                    quote?.base_price != null
+                                                    toOptionalNumber(prev.original_price_per_day) ??
+                                                    (quote?.base_price != null
                                                         ? parsePrice(quote.base_price)
-                                                        : prev.original_price_per_day ??
-                                                          parsePrice(
+                                                        : parsePrice(
                                                               prev.base_price ?? prev.price_per_day ?? 0,
-                                                          ),
+                                                          )),
                                             }),
                                         )
                                     }
@@ -2460,15 +2462,15 @@ const BookingForm: React.FC<BookingFormProps> = ({
                                                           ? parsePrice(quote.rental_rate_casco)
                                                           : prev.price_per_day,
                                                 original_price_per_day:
-                                                    quote?.base_price_casco != null
+                                                    toOptionalNumber(prev.original_price_per_day) ??
+                                                    (quote?.base_price_casco != null
                                                         ? parsePrice(quote.base_price_casco)
-                                                        : prev.original_price_per_day ??
-                                                          parsePrice(
+                                                        : parsePrice(
                                                               prev.base_price_casco ??
                                                                   prev.base_price ??
                                                                   prev.price_per_day ??
                                                                   0,
-                                                          ),
+                                                          )),
                                             }),
                                         )
                                     }

--- a/components/admin/BookingForm.tsx
+++ b/components/admin/BookingForm.tsx
@@ -1947,10 +1947,21 @@ const BookingForm: React.FC<BookingFormProps> = ({
     if (!bookingInfo) return null;
 
     const days = quote?.days ?? bookingInfo.days ?? 0;
+    const pricePerDayValue = toOptionalNumber(bookingInfo.price_per_day);
+    const storedOriginalRate = bookingInfo.with_deposit
+        ? toOptionalNumber(bookingInfo.base_price)
+        : toOptionalNumber(bookingInfo.base_price_casco);
+    const fallbackOriginalRate =
+        toOptionalNumber(bookingInfo.original_price_per_day) ??
+        storedOriginalRate ??
+        pricePerDayValue ??
+        0;
     const baseRate = bookingInfo.with_deposit
-        ? quote?.rental_rate ?? bookingInfo.price_per_day ?? 0
-        : quote?.rental_rate_casco ?? bookingInfo.price_per_day ?? 0;
-    const discountedRate = quote?.price_per_day ?? baseRate;
+        ? quote?.base_price ?? quote?.rental_rate ?? fallbackOriginalRate
+        : quote?.base_price_casco ?? quote?.rental_rate_casco ?? fallbackOriginalRate;
+    const discountedRate = bookingInfo.with_deposit
+        ? quote?.price_per_day ?? quote?.rental_rate ?? pricePerDayValue ?? baseRate
+        : quote?.price_per_day ?? quote?.rental_rate_casco ?? pricePerDayValue ?? baseRate;
     const discountedSubtotal = bookingInfo.with_deposit
         ? quote?.sub_total ?? quote?.sub_total_casco ?? null
         : quote?.sub_total_casco ?? quote?.sub_total ?? null;

--- a/components/admin/BookingForm.tsx
+++ b/components/admin/BookingForm.tsx
@@ -1901,10 +1901,23 @@ const BookingForm: React.FC<BookingFormProps> = ({
     if (!bookingInfo) return null;
 
     const days = quote?.days ?? bookingInfo.days ?? 0;
-    const baseRate = bookingInfo.with_deposit
-        ? quote?.rental_rate ?? bookingInfo.price_per_day ?? 0
-        : quote?.rental_rate_casco ?? bookingInfo.price_per_day ?? 0;
-    const discountedRate = quote?.price_per_day ?? baseRate;
+    const pricePerDayValue = toOptionalNumber(bookingInfo.price_per_day);
+    const basePriceValue = toOptionalNumber(bookingInfo.base_price);
+    const basePriceCascoValue = toOptionalNumber(bookingInfo.base_price_casco);
+    const originalPriceValue = toOptionalNumber(bookingInfo.original_price_per_day);
+    const rentalRate = bookingInfo.with_deposit ? quote?.rental_rate : quote?.rental_rate_casco;
+    const fallbackOriginalDailyRate = bookingInfo.with_deposit
+        ? basePriceValue ?? originalPriceValue ?? pricePerDayValue ?? 0
+        : basePriceCascoValue ?? basePriceValue ?? originalPriceValue ?? pricePerDayValue ?? 0;
+    const resolvedOriginalDailyRate =
+        typeof rentalRate === "number" && Number.isFinite(rentalRate)
+            ? rentalRate
+            : fallbackOriginalDailyRate;
+
+    const discountedRate =
+        typeof quote?.price_per_day === "number" && Number.isFinite(quote.price_per_day)
+            ? quote.price_per_day
+            : pricePerDayValue ?? resolvedOriginalDailyRate ?? 0;
     const discountedSubtotal = bookingInfo.with_deposit
         ? quote?.sub_total ?? quote?.sub_total_casco ?? null
         : quote?.sub_total_casco ?? quote?.sub_total ?? null;
@@ -1924,30 +1937,50 @@ const BookingForm: React.FC<BookingFormProps> = ({
     const discountedTotalQuote = bookingInfo.with_deposit
         ? quote?.total ?? quote?.total_casco ?? null
         : quote?.total_casco ?? quote?.total ?? null;
-    const subtotalDisplay = discountedSubtotal ?? originalTotals.current.subtotal;
-    const totalDisplay = discountedTotalQuote ?? originalTotals.current.total;
+    const hasDiscountDetails = discount !== 0 && (discountedTotalQuote ?? 0) > 0;
+    const summaryDailyRateBase =
+        typeof resolvedOriginalDailyRate === "number"
+            ? resolvedOriginalDailyRate
+            : discountedRate;
+    const summaryDailyRate = hasDiscountDetails ? summaryDailyRateBase : discountedRate;
+    const rawDiscountedSubtotal =
+        typeof discountedSubtotal === "number"
+            ? discountedSubtotal
+            : Number(originalTotals.current.subtotal ?? 0);
+    const rawDiscountedTotal =
+        typeof discountedTotalQuote === "number"
+            ? discountedTotalQuote
+            : Number(originalTotals.current.total ?? 0);
+    const summarySubtotalValue = hasDiscountDetails
+        ? rawDiscountedSubtotal + discount
+        : rawDiscountedSubtotal;
+    const summaryTotalValue = hasDiscountDetails ? rawDiscountedTotal + discount : rawDiscountedTotal;
+    const summarySubtotalDisplay = Math.round(summarySubtotalValue * 100) / 100;
+    const summaryTotalDisplay = Math.round(summaryTotalValue * 100) / 100;
+    const discountedTotalDisplay = Math.round(rawDiscountedTotal * 100) / 100;
     const advancePaymentValue = toOptionalNumber(bookingInfo.advance_payment) ?? 0;
     const totalServicesValue =
         typeof quote?.total_services === "number"
             ? quote.total_services
             : toOptionalNumber(bookingInfo.total_services) ?? 0;
     const totalServicesDisplay = Math.round(totalServicesValue * 100) / 100;
-    const restToPay = totalDisplay - advancePaymentValue;
+    const restToPay = summaryTotalDisplay - advancePaymentValue;
     const restToPayEuroDisplay = Number.isFinite(restToPay)
         ? Math.round(restToPay * 100) / 100
         : null;
 
     const depositWaived = bookingInfo.deposit_waived === true;
-    const subtotalLei = formatLeiAmount(subtotalDisplay);
-    const totalLei = formatLeiAmount(totalDisplay);
+    const subtotalLei = formatLeiAmount(summarySubtotalDisplay);
+    const totalLei = formatLeiAmount(summaryTotalDisplay);
+    const discountedTotalLei = formatLeiAmount(discountedTotalDisplay);
     const restToPayLei = formatLeiAmount(restToPay);
     const discountLei = formatLeiAmount(discount);
     const wheelPrizeDiscountLei = formatLeiAmount(normalizedWheelPrizeDiscount);
-    const baseRateLei = formatLeiAmount(baseRate);
+    const summaryDailyRateRounded = Math.round(summaryDailyRate * 100) / 100;
+    const baseRateLei = formatLeiAmount(summaryDailyRateRounded);
     const roundedDiscountedRate = Math.round(discountedRate);
     const roundedDiscountedRateLei = formatLeiAmount(roundedDiscountedRate);
     const advancePaymentLei = formatLeiAmount(advancePaymentValue);
-    const hasDiscountDetails = discount !== 0 && (discountedTotalQuote ?? 0) > 0;
 
     const handleUpdateBooking = async () => {
         if (!bookingInfo || bookingInfo.id == null) {
@@ -2578,7 +2611,7 @@ const BookingForm: React.FC<BookingFormProps> = ({
                                             )}
                                             <li className="ms-5 flex justify-between border-b border-b-1 mb-1">
                                                 <span>Total:</span>
-                                                <span>{totalLei ?? "—"}</span>
+                                                <span>{discountedTotalLei ?? "—"}</span>
                                             </li>
                                         </ul>
                                     </div>
@@ -2587,7 +2620,7 @@ const BookingForm: React.FC<BookingFormProps> = ({
                             <div className="pt-4 border-t border-gray-300">
                                 <div className="font-dm-sans text-sm flex justify-between border-b border-b-1 mb-1">
                                     <span>Preț per zi:</span>
-                                    <span>{baseRate}€ x {days} zile</span>
+                                    <span>{summaryDailyRateRounded}€ x {days} zile</span>
                                 </div>
                                 {totalServicesDisplay > 0 && (
                                     <div className="font-dm-sans text-sm flex justify-between border-b border-b-1 mb-1">
@@ -2596,7 +2629,7 @@ const BookingForm: React.FC<BookingFormProps> = ({
                                 )}
                                 <div className="font-dm-sans text-sm flex justify-between border-b border-b-1 mb-1">
                                     <span>Subtotal:</span>
-                                    <span>{subtotalDisplay}€</span>
+                                    <span>{summarySubtotalDisplay}€</span>
                                 </div>
                                 {discount !== 0 && (
                                     <div className="font-dm-sans text-sm flex justify-between border-b border-b-1 mb-1">
@@ -2631,7 +2664,7 @@ const BookingForm: React.FC<BookingFormProps> = ({
                                 )}
                                 <div className="font-dm-sans text-sm font-semibold flex justify-between">
                                     <span>Total:</span>
-                                    <span>{totalDisplay}€</span>
+                                    <span>{summaryTotalDisplay}€</span>
                                 </div>
                                 {hasDiscountDetails && (
                                     <div className="font-dm-sans text-sm mt-3">
@@ -2639,7 +2672,7 @@ const BookingForm: React.FC<BookingFormProps> = ({
                                         <ul className="list-disc">
                                             <li className="ms-5 flex justify-between border-b border-b-1 mb-1">
                                                 <span>Preț nou pe zi:</span>
-                                                <span>{Math.round(discountedRate)}€ x {days} zile</span>
+                                                <span>{roundedDiscountedRate}€ x {days} zile</span>
                                             </li>
                                             {discount > 0 && (
                                                 <li className="ms-5 flex justify-between border-b border-b-1 mb-1">
@@ -2649,7 +2682,7 @@ const BookingForm: React.FC<BookingFormProps> = ({
                                             )}
                                             <li className="ms-5 flex justify-between border-b border-b-1 mb-1">
                                                 <span>Total:</span>
-                                                <span>{totalDisplay}€</span>
+                                                <span>{discountedTotalDisplay}€</span>
                                             </li>
                                         </ul>
                                     </div>

--- a/components/admin/BookingForm.tsx
+++ b/components/admin/BookingForm.tsx
@@ -1948,17 +1948,19 @@ const BookingForm: React.FC<BookingFormProps> = ({
 
     const days = quote?.days ?? bookingInfo.days ?? 0;
     const pricePerDayValue = toOptionalNumber(bookingInfo.price_per_day);
-    const storedOriginalRate = bookingInfo.with_deposit
+    const originalRateFromBooking = toOptionalNumber(bookingInfo.original_price_per_day);
+    const originalRateFromPlan = bookingInfo.with_deposit
         ? toOptionalNumber(bookingInfo.base_price)
         : toOptionalNumber(bookingInfo.base_price_casco);
-    const fallbackOriginalRate =
-        toOptionalNumber(bookingInfo.original_price_per_day) ??
-        storedOriginalRate ??
+    const originalRateFromQuote = bookingInfo.with_deposit
+        ? toOptionalNumber(quote?.base_price ?? quote?.rental_rate)
+        : toOptionalNumber(quote?.base_price_casco ?? quote?.rental_rate_casco);
+    const baseRate =
+        originalRateFromBooking ??
+        originalRateFromPlan ??
+        originalRateFromQuote ??
         pricePerDayValue ??
         0;
-    const baseRate = bookingInfo.with_deposit
-        ? quote?.base_price ?? quote?.rental_rate ?? fallbackOriginalRate
-        : quote?.base_price_casco ?? quote?.rental_rate_casco ?? fallbackOriginalRate;
     const discountedRate = bookingInfo.with_deposit
         ? quote?.price_per_day ?? quote?.rental_rate ?? pricePerDayValue ?? baseRate
         : quote?.price_per_day ?? quote?.rental_rate_casco ?? pricePerDayValue ?? baseRate;
@@ -2411,13 +2413,18 @@ const BookingForm: React.FC<BookingFormProps> = ({
                                                 ...prev,
                                                 with_deposit: true,
                                                 price_per_day:
-                                                    quote?.rental_rate != null
-                                                        ? parsePrice(quote.rental_rate)
-                                                        : prev.price_per_day,
+                                                    quote?.price_per_day != null
+                                                        ? parsePrice(quote.price_per_day)
+                                                        : quote?.rental_rate != null
+                                                          ? parsePrice(quote.rental_rate)
+                                                          : prev.price_per_day,
                                                 original_price_per_day:
-                                                    quote?.rental_rate != null
-                                                        ? parsePrice(quote.rental_rate)
-                                                        : prev.original_price_per_day,
+                                                    quote?.base_price != null
+                                                        ? parsePrice(quote.base_price)
+                                                        : prev.original_price_per_day ??
+                                                          parsePrice(
+                                                              prev.base_price ?? prev.price_per_day ?? 0,
+                                                          ),
                                             }),
                                         )
                                     }
@@ -2447,13 +2454,21 @@ const BookingForm: React.FC<BookingFormProps> = ({
                                                 ...prev,
                                                 with_deposit: false,
                                                 price_per_day:
-                                                    quote?.rental_rate_casco != null
-                                                        ? parsePrice(quote.rental_rate_casco)
-                                                        : prev.price_per_day,
+                                                    quote?.price_per_day != null
+                                                        ? parsePrice(quote.price_per_day)
+                                                        : quote?.rental_rate_casco != null
+                                                          ? parsePrice(quote.rental_rate_casco)
+                                                          : prev.price_per_day,
                                                 original_price_per_day:
-                                                    quote?.rental_rate_casco != null
-                                                        ? parsePrice(quote.rental_rate_casco)
-                                                        : prev.original_price_per_day,
+                                                    quote?.base_price_casco != null
+                                                        ? parsePrice(quote.base_price_casco)
+                                                        : prev.original_price_per_day ??
+                                                          parsePrice(
+                                                              prev.base_price_casco ??
+                                                                  prev.base_price ??
+                                                                  prev.price_per_day ??
+                                                                  0,
+                                                          ),
                                             }),
                                         )
                                     }

--- a/lib/__tests__/pagination.test.ts
+++ b/lib/__tests__/pagination.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { generatePaginationSequence } from "../pagination";
+
+describe("generatePaginationSequence", () => {
+  it("returnează toate paginile când numărul total este mic", () => {
+    expect(generatePaginationSequence(1, 5)).toEqual([1, 2, 3, 4, 5]);
+    expect(generatePaginationSequence(3, 8)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+
+  it("deplasează fereastra de pagini odată cu pagina curentă", () => {
+    expect(generatePaginationSequence(1, 12)).toEqual([
+      1,
+      2,
+      3,
+      "ellipsis",
+      10,
+      11,
+      12,
+    ]);
+
+    expect(generatePaginationSequence(3, 12)).toEqual([
+      1,
+      2,
+      3,
+      4,
+      "ellipsis",
+      10,
+      11,
+      12,
+    ]);
+
+    expect(generatePaginationSequence(6, 12)).toEqual([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      "ellipsis",
+      10,
+      11,
+      12,
+    ]);
+
+    expect(generatePaginationSequence(10, 12)).toEqual([
+      1,
+      2,
+      3,
+      "ellipsis",
+      9,
+      10,
+      11,
+      12,
+    ]);
+  });
+
+  it("tratează valorile out-of-range corect", () => {
+    expect(generatePaginationSequence(-5, 3)).toEqual([1, 2, 3]);
+    expect(generatePaginationSequence(100, 2)).toEqual([1, 2]);
+  });
+});

--- a/lib/pagination.ts
+++ b/lib/pagination.ts
@@ -1,0 +1,65 @@
+export type PaginationSegment = number | "ellipsis";
+
+const clampPage = (value: number, min: number, max: number): number => {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.min(Math.max(Math.trunc(value), min), max);
+};
+
+/**
+ * Construiește o secvență de pagini cu marcaje de tip "ellipsis" care se deplasează
+ * odată cu pagina curentă. Se păstrează primele și ultimele pagini, vecinii
+ * apropiați și se inserează automat numerele lipsă atunci când diferența este de
+ * o singură pagină.
+ */
+export const generatePaginationSequence = (
+  currentPage: number,
+  lastPage: number,
+): PaginationSegment[] => {
+  const totalPages = clampPage(lastPage, 1, Number.MAX_SAFE_INTEGER);
+  const activePage = clampPage(currentPage, 1, totalPages);
+
+  if (totalPages <= 8) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+
+  const seeds = [
+    1,
+    2,
+    3,
+    totalPages,
+    totalPages - 1,
+    totalPages - 2,
+    activePage - 1,
+    activePage,
+    activePage + 1,
+  ];
+
+  const uniquePages = Array.from(
+    new Set(
+      seeds.filter(
+        (page) => Number.isFinite(page) && page >= 1 && page <= totalPages,
+      ),
+    ),
+  ).sort((a, b) => a - b);
+
+  const segments: PaginationSegment[] = [];
+  let previousPage: number | null = null;
+
+  uniquePages.forEach((page) => {
+    if (previousPage != null) {
+      const gap = page - previousPage;
+      if (gap === 2) {
+        segments.push(previousPage + 1);
+      } else if (gap > 2) {
+        segments.push("ellipsis");
+      }
+    }
+
+    segments.push(page);
+    previousPage = page;
+  });
+
+  return segments;
+};


### PR DESCRIPTION
## Summary
- ensure the admin booking popup keeps the original daily rate and totals in the payment summary when a discount is present
- surface the discounted daily rate and totals only inside the "Detalii discount" blocks in both lei and euro sections

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e53b2f14608329bd40942a2027f230