### PR TITLE
Prevent preloading unused hero images on mobile

### DIFF
--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -64,6 +64,7 @@ const HeroSection = () => {
                         alt="Fundal aeroport"
                         fill
                         priority
+                        media="(max-width: 639px)"
                         placeholder="blur"
                         sizes="(max-width: 639px) 100vw, 0vw"
                         quality={60}
@@ -76,6 +77,7 @@ const HeroSection = () => {
                         alt="Fundal aeroport"
                         fill
                         priority
+                        media="(min-width: 640px)"
                         placeholder="blur"
                         sizes="(min-width: 640px) 100vw, 0vw"
                         quality={60}


### PR DESCRIPTION
## Summary
- add responsive media conditions to the hero background images so only the relevant asset preloads for the current viewport

## Testing
- npm run lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e64f083610832994a0297c5fc4b736