### PR TITLE
Fix admin booking plan rate toggle pricing

### DIFF
--- a/components/admin/BookingForm.tsx
+++ b/components/admin/BookingForm.tsx
@@ -1959,9 +1959,9 @@ const BookingForm: React.FC<BookingFormProps> = ({
         ? toOptionalNumber(quote?.base_price ?? quote?.rental_rate)
         : toOptionalNumber(quote?.base_price_casco ?? quote?.rental_rate_casco);
     const baseRate =
-        originalRateFromBooking ??
         originalRateFromPlan ??
         originalRateFromQuote ??
+        originalRateFromBooking ??
         pricePerDayValue ??
         0;
     const discountedRate = bookingInfo.with_deposit

--- a/components/admin/BookingForm.tsx
+++ b/components/admin/BookingForm.tsx
@@ -1965,8 +1965,8 @@ const BookingForm: React.FC<BookingFormProps> = ({
         pricePerDayValue ??
         0;
     const discountedRate = bookingInfo.with_deposit
-        ? quote?.price_per_day ?? quote?.rental_rate ?? pricePerDayValue ?? baseRate
-        : quote?.price_per_day ?? quote?.rental_rate_casco ?? pricePerDayValue ?? baseRate;
+        ? quote?.rental_rate ?? quote?.price_per_day ?? pricePerDayValue ?? baseRate
+        : quote?.rental_rate_casco ?? quote?.price_per_day ?? pricePerDayValue ?? baseRate;
     const discountedSubtotal = bookingInfo.with_deposit
         ? quote?.sub_total ?? quote?.sub_total_casco ?? null
         : quote?.sub_total_casco ?? quote?.sub_total ?? null;
@@ -2416,10 +2416,10 @@ const BookingForm: React.FC<BookingFormProps> = ({
                                                 ...prev,
                                                 with_deposit: true,
                                                 price_per_day:
-                                                    quote?.price_per_day != null
-                                                        ? parsePrice(quote.price_per_day)
-                                                        : quote?.rental_rate != null
-                                                          ? parsePrice(quote.rental_rate)
+                                                    quote?.rental_rate != null
+                                                        ? parsePrice(quote.rental_rate)
+                                                        : quote?.price_per_day != null
+                                                          ? parsePrice(quote.price_per_day)
                                                           : prev.price_per_day,
                                                 original_price_per_day:
                                                     toOptionalNumber(prev.original_price_per_day) ??
@@ -2457,10 +2457,10 @@ const BookingForm: React.FC<BookingFormProps> = ({
                                                 ...prev,
                                                 with_deposit: false,
                                                 price_per_day:
-                                                    quote?.price_per_day != null
-                                                        ? parsePrice(quote.price_per_day)
-                                                        : quote?.rental_rate_casco != null
-                                                          ? parsePrice(quote.rental_rate_casco)
+                                                    quote?.rental_rate_casco != null
+                                                        ? parsePrice(quote.rental_rate_casco)
+                                                        : quote?.price_per_day != null
+                                                          ? parsePrice(quote.price_per_day)
                                                           : prev.price_per_day,
                                                 original_price_per_day:
                                                     toOptionalNumber(prev.original_price_per_day) ??

--- a/components/admin/BookingForm.tsx
+++ b/components/admin/BookingForm.tsx
@@ -1350,8 +1350,8 @@ const BookingForm: React.FC<BookingFormProps> = ({
                         toOptionalNumber(data.base_price_casco) ??
                         toOptionalNumber(prev.base_price_casco);
                     const selectedRateCandidate = preferCasco
-                        ? cascoRateCandidate ?? depositRateCandidate ?? prevPricePerDay
-                        : depositRateCandidate ?? cascoRateCandidate ?? prevPricePerDay;
+                        ? cascoRateCandidate ?? prevPricePerDay ?? depositRateCandidate
+                        : depositRateCandidate ?? prevPricePerDay ?? cascoRateCandidate;
                     const normalizedSelectedRate =
                         typeof selectedRateCandidate === "number" && Number.isFinite(selectedRateCandidate)
                             ? Math.round(selectedRateCandidate * 100) / 100
@@ -1419,12 +1419,14 @@ const BookingForm: React.FC<BookingFormProps> = ({
                         toOptionalNumber(normalizedWheelPrize?.prize_id) ??
                         toOptionalNumber(prev.wheel_of_fortune_prize_id);
 
+                    const previousSubtotal = toOptionalNumber(prev.sub_total);
+                    const previousTotal = toOptionalNumber(prev.total);
                     const nextSubtotal = preferCasco
-                        ? normalizedSubtotalCasco ?? normalizedSubtotalDeposit
-                        : normalizedSubtotalDeposit ?? normalizedSubtotalCasco;
+                        ? normalizedSubtotalCasco ?? previousSubtotal ?? normalizedSubtotalDeposit
+                        : normalizedSubtotalDeposit ?? previousSubtotal ?? normalizedSubtotalCasco;
                     const nextTotal = preferCasco
-                        ? normalizedTotalCasco ?? normalizedTotalDeposit
-                        : normalizedTotalDeposit ?? normalizedTotalCasco;
+                        ? normalizedTotalCasco ?? previousTotal ?? normalizedTotalDeposit
+                        : normalizedTotalDeposit ?? previousTotal ?? normalizedTotalCasco;
 
                     return {
                         ...prev,


### PR DESCRIPTION
## Summary
- prioritize plan-specific rental rates when toggling between deposit plans so the daily price updates immediately in the admin booking form
- ensure the displayed discounted rate uses the appropriate CASCO rental rate when the reservation is set without guarantee

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e65a26b0bc83299476fc31069cf4a5